### PR TITLE
Remove uniqueness validator on question_sheet.

### DIFF
--- a/app/models/fe/question_sheet.rb
+++ b/app/models/fe/question_sheet.rb
@@ -17,8 +17,6 @@ module Fe
     scope :archived, -> { where(:archived => true) }
 
     validates_presence_of :label
-    #  validates_length_of :label, :maximum => 60, :allow_nil => true
-    validates_uniqueness_of :label
 
     serialize :languages, Array
 


### PR DESCRIPTION
This causes problems in smapp because smapp adds an organization_id
scope. Different organizations should be allowed to have question sheets
with the same name. Since only a very small number of admin users are
creating/editing question sheets, I think it's ok to remove this slight
protection against stupidity.