### PR TITLE
add logic to handle optional refs

### DIFF
--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -110,10 +110,10 @@ module Fe
     end
 
     def hidden_by_conditional?(answer_sheet, page, prev_el)
-      (prev_el ||= previous_element(answer_sheet.question_sheet, page)) &&
-        prev_el.is_a?(Fe::Question) &&
-        prev_el.conditional == self &&
-        !prev_el.conditional_match(answer_sheet)
+      !!((prev_el ||= previous_element(answer_sheet.question_sheet, page)) &&
+          prev_el.is_a?(Fe::Question) &&
+          prev_el.conditional == self &&
+          !prev_el.conditional_match(answer_sheet))
     end
 
     def hidden_by_choice_field?(answer_sheet)

--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -152,6 +152,14 @@ module Fe
       question.label.split(/:| \(/).first
     end
 
+    def optional?
+      question.hidden?(applicant_answer_sheet)
+    end
+
+    def required?
+      !optional?
+    end
+
     protected
     # if the email address has changed, we have to trash the old reference answers
     def check_email_change

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -28,4 +28,109 @@ describe Fe::ReferenceSheet do
     r = create(:reference_sheet, applicant_answer_sheet: a)
     expect(r.applicant).to eq(a.applicant)
   end 
+
+  it 'returns the user for applicant' do
+    p = create(:fe_person)
+    a = create(:answer_sheet, applicant_id: p.id)
+    r = create(:reference_sheet, applicant_answer_sheet: a)
+    expect(r.applicant).to eq(a.applicant)
+  end 
+
+  context '#required?' do
+    it 'should return the opposite of required? when optional? is false' do
+      question_sheet = FactoryGirl.create(:question_sheet_with_pages)
+      application = FactoryGirl.create(:answer_sheet)
+      application.question_sheets << question_sheet
+      element = FactoryGirl.create(:reference_element, label: "Reference question here", required: true)
+      reference = FactoryGirl.create(:reference_sheet, applicant_answer_sheet: application, question: element)
+      expect(reference.optional?).to be false
+      expect(reference.required?).to be true
+    end
+    it 'should return the opposite of required? when optional? is true' do
+      question_sheet = FactoryGirl.create(:question_sheet_with_pages)
+      application = FactoryGirl.create(:answer_sheet)
+      application.question_sheets << question_sheet
+      element = FactoryGirl.create(:reference_element, label: "Reference question here", required: true)
+      reference = FactoryGirl.create(:reference_sheet, applicant_answer_sheet: application, question: element)
+      allow(reference).to receive(:optional?).and_return(true)
+      expect(reference.optional?).to be true
+      expect(reference.required?).to be false
+    end
+  end
+
+  context '#optional?' do
+    it 'returns true when the ref question element is hidden from a yes/no choice_field' do
+      question_sheet = FactoryGirl.create(:question_sheet_with_pages)
+      choice_field = FactoryGirl.create(:choice_field_element, label: "Is the reference required?")
+      question_sheet.pages.reload
+      question_sheet.pages[3].elements << choice_field
+      element = FactoryGirl.create(:reference_element, label: "Reference question here", choice_field_id: choice_field.id, required: true)
+      question_sheet.pages[3].elements << element
+
+      application = FactoryGirl.create(:answer_sheet)
+      application.question_sheets << question_sheet
+      reference = FactoryGirl.create(:reference_sheet, applicant_answer_sheet: application, question: element)
+
+      # make the answer to the conditional question 'no' so that the ref is not required (optional true)
+      choice_field.set_response("no", application)
+      choice_field.save_response(application)
+
+      expect(reference.optional?).to be true
+    end
+    it 'returns false when the ref question element is visible from a yes/no choice_field' do
+      question_sheet = FactoryGirl.create(:question_sheet_with_pages)
+      choice_field = FactoryGirl.create(:choice_field_element, label: "Is the reference required?")
+      question_sheet.pages.reload
+      question_sheet.pages[3].elements << choice_field
+      element = FactoryGirl.create(:reference_element, label: "Reference question here", choice_field_id: choice_field.id, required: true)
+      question_sheet.pages[3].elements << element
+
+      question_sheet.pages[3].elements << choice_field
+      application = FactoryGirl.create(:answer_sheet)
+      application.question_sheets << question_sheet
+      reference = FactoryGirl.create(:reference_sheet, applicant_answer_sheet: application, question: element)
+
+      # make the answer to the conditional question 'yes' so that the ref is required (optional false)
+      choice_field.set_response("yes", application)
+      choice_field.save_response(application)
+
+      expect(reference.optional?).to be false
+    end
+    it 'returns false when the ref question element is hidden from a conditional element' do
+      question_sheet = FactoryGirl.create(:question_sheet_with_pages)
+      choice_field = FactoryGirl.create(:choice_field_element, label: "Is the reference required?", conditional_type: "Fe::Element", conditional_answer: "yes")
+      question_sheet.pages.reload
+      question_sheet.pages[3].elements << choice_field
+      element = FactoryGirl.create(:reference_element, label: "Reference question here", required: true)
+      question_sheet.pages[3].elements << element
+
+      application = FactoryGirl.create(:answer_sheet)
+      application.question_sheets << question_sheet
+      reference = FactoryGirl.create(:reference_sheet, applicant_answer_sheet: application, question: element)
+
+      # make the answer to the conditional question 'no' so that the ref is not required (optional true)
+      choice_field.set_response("no", application)
+      choice_field.save_response(application)
+
+      expect(reference.optional?).to be true
+    end
+    it 'returns false when the ref question element is visible from a conditional element' do
+      question_sheet = FactoryGirl.create(:question_sheet_with_pages)
+      choice_field = FactoryGirl.create(:choice_field_element, label: "Is the reference required?", conditional_type: "Fe::Element", conditional_answer: "yes")
+      question_sheet.pages.reload
+      question_sheet.pages[3].elements << choice_field
+      element = FactoryGirl.create(:reference_element, label: "Reference question here", required: true)
+      question_sheet.pages[3].elements << element
+
+      application = FactoryGirl.create(:answer_sheet)
+      application.question_sheets << question_sheet
+      reference = FactoryGirl.create(:reference_sheet, applicant_answer_sheet: application, question: element)
+
+      # make the answer to the conditional question 'yes' so that the ref is required (optional false)
+      choice_field.set_response("yes", application)
+      choice_field.save_response(application)
+
+      expect(reference.optional?).to be false
+    end
+  end
 end


### PR DESCRIPTION
@twinge both Canada and US have requested a way to make references optional based on the answer to a specific question, generally something along the lines of "Have you been on project before?" then they can skip one of the references

also adds a required? helper that returns the opposite of optional?

a ref element that is hidden by a conditional element is optional.. it's
left to the enclosing app to set the application completed status based
on whether all the non-optional/required refs are completed