### PR TITLE
don't store empty string for translations

### DIFF
--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -39,6 +39,7 @@ module Fe
 
     before_validation :set_defaults, :on => :create
     before_save :set_conditional_element
+    before_save :clear_empty_translations
     after_save :update_page_all_element_ids
     after_save :update_any_previous_conditional_elements
 
@@ -261,6 +262,14 @@ module Fe
       end
 
       pages.reload.each do |p| p.rebuild_all_element_ids end
+    end
+
+    def clear_empty_translations
+      %w(label tip content).each do |prefix|
+        send("#{prefix}_translations").reject!{ |k,v|
+          v.empty?
+        }
+      end
     end
 
     protected

--- a/spec/models/fe/element_spec.rb
+++ b/spec/models/fe/element_spec.rb
@@ -324,4 +324,14 @@ describe Fe::Element do
       expect(page.reload.all_element_ids).to eq("#{grid.id},#{textfield.id}")
     end
   end
+
+  context 'translations' do
+    it 'should store nil instread of an empty string' do
+      e = create(:text_field_element, label_translations: { 'fr' => '' }, tip_translations: { 'fr' => '' }, content_translations: { 'fr' => '' })
+      e.save!
+      expect(e.label_translations['fr']).to be nil
+      expect(e.tip_translations['fr']).to be nil
+      expect(e.content_translations['fr']).to be nil
+    end
+  end
 end


### PR DESCRIPTION
@twinge we're having a problem with empty labels showing up.. when you update an element it was putting in the empty strings