### PR TITLE
handle changing the ref question sheet properly

### DIFF
--- a/app/models/fe/reference_question.rb
+++ b/app/models/fe/reference_question.rb
@@ -2,6 +2,9 @@
 # - a question that provides a fields to specify a reference
 module Fe
   class ReferenceQuestion < Question
+    has_many :reference_sheets, foreign_key: :question_id
+
+    after_save :update_references_question_sheet_ids
 
     def response(app=nil)
       return unless app
@@ -28,5 +31,8 @@ module Fe
       "fe/reference_#{style}"
     end
 
+    def update_references_question_sheet_ids
+      reference_sheets.where(status: :created).update_all(question_sheet_id: related_question_sheet_id, updated_at: Time.now)
+    end
   end
 end

--- a/db/migrate/20151021184250_add_question_sheet_id_in_refs.rb
+++ b/db/migrate/20151021184250_add_question_sheet_id_in_refs.rb
@@ -1,0 +1,9 @@
+class AddQuestionSheetIdInRefs < ActiveRecord::Migration
+  def change
+    add_column Fe::ReferenceSheet.table_name, :question_sheet_id, :integer
+    Fe::ReferenceSheet.reset_column_information
+
+    # set question_sheet_id on all refs
+    Fe::ReferenceSheet.joins(:question).update_all("question_sheet_id = related_question_sheet_id")
+  end
+end

--- a/db/migrate/20151021184250_add_question_sheet_id_in_refs.rb
+++ b/db/migrate/20151021184250_add_question_sheet_id_in_refs.rb
@@ -1,9 +1,12 @@
 class AddQuestionSheetIdInRefs < ActiveRecord::Migration
   def change
     add_column Fe::ReferenceSheet.table_name, :question_sheet_id, :integer
-    Fe::ReferenceSheet.reset_column_information
 
-    # set question_sheet_id on all refs
-    Fe::ReferenceSheet.joins(:question).update_all("question_sheet_id = related_question_sheet_id")
+    # set initial question_sheet_id on all refs
+    # NOTE: doing an update on a join query is a pain to do in both mysql and postgres
+    # and since there's not that many reference questions, this should be fine
+    Fe::ReferenceQuestion.all.each do |rq|
+      Fe::ReferenceSheet.where(question_id: rq.id).update_all(question_sheet_id: rq.related_question_sheet_id)
+    end
   end
 end

--- a/spec/dummy/db/migrate/20151021190027_add_question_sheet_id_in_refs.fe_engine.rb
+++ b/spec/dummy/db/migrate/20151021190027_add_question_sheet_id_in_refs.fe_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from fe_engine (originally 20151021184250)
+class AddQuestionSheetIdInRefs < ActiveRecord::Migration
+  def change
+    add_column Fe::ReferenceSheet.table_name, :question_sheet_id, :integer
+    Fe::ReferenceSheet.reset_column_information
+
+    # set question_sheet_id on all refs
+    Fe::ReferenceSheet.joins(:question).update_all("question_sheet_id = related_question_sheet_id")
+  end
+end

--- a/spec/dummy/db/migrate/20151021190027_add_question_sheet_id_in_refs.fe_engine.rb
+++ b/spec/dummy/db/migrate/20151021190027_add_question_sheet_id_in_refs.fe_engine.rb
@@ -2,9 +2,8 @@
 class AddQuestionSheetIdInRefs < ActiveRecord::Migration
   def change
     add_column Fe::ReferenceSheet.table_name, :question_sheet_id, :integer
-    Fe::ReferenceSheet.reset_column_information
 
-    # set question_sheet_id on all refs
-    Fe::ReferenceSheet.joins(:question).update_all("question_sheet_id = related_question_sheet_id")
+    # set initial question_sheet_id on all refs
+    Fe::ReferenceSheet.joins(:question).update_all("#{Fe::ReferenceSheet.table_name}.question_sheet_id = #{Fe::ReferenceQuestion.table_name}.related_question_sheet_id")
   end
 end

--- a/spec/dummy/db/migrate/20151021190027_add_question_sheet_id_in_refs.fe_engine.rb
+++ b/spec/dummy/db/migrate/20151021190027_add_question_sheet_id_in_refs.fe_engine.rb
@@ -4,6 +4,10 @@ class AddQuestionSheetIdInRefs < ActiveRecord::Migration
     add_column Fe::ReferenceSheet.table_name, :question_sheet_id, :integer
 
     # set initial question_sheet_id on all refs
-    Fe::ReferenceSheet.joins(:question).update_all("#{Fe::ReferenceSheet.table_name}.question_sheet_id = #{Fe::ReferenceQuestion.table_name}.related_question_sheet_id")
+    # NOTE: doing an update on a join query is a pain to do in both mysql and postgres
+    # and since there's not that many reference questions, this should be fine
+    Fe::ReferenceQuestion.all.each do |rq|
+      Fe::ReferenceSheet.where(question_id: rq.id).update_all(question_sheet_id: rq.related_question_sheet_id)
+    end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150930191756) do
+ActiveRecord::Schema.define(version: 20151021190027) do
 
   create_table "create_fe_phone_numbers", force: true do |t|
     t.string   "number"
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 20150930191756) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "locale",                    default: "en"
+    t.integer  "question_sheet_id"
   end
 
   add_index "fe_references", ["applicant_answer_sheet_id"], name: "index_fe_references_on_applicant_answer_sheet_id", using: :btree

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -13,19 +13,6 @@
 
 ActiveRecord::Schema.define(version: 20151021190027) do
 
-  create_table "create_fe_phone_numbers", force: true do |t|
-    t.string   "number"
-    t.string   "extensions"
-    t.integer  "person_id"
-    t.string   "location"
-    t.boolean  "primary"
-    t.string   "txt_to_email"
-    t.integer  "carrier_id"
-    t.datetime "email_updated_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "fe_addresses", force: true do |t|
     t.datetime "startdate"
     t.datetime "enddate"
@@ -122,10 +109,10 @@ ActiveRecord::Schema.define(version: 20151021190027) do
     t.string   "conditional_type"
     t.text     "conditional_answer"
     t.integer  "choice_field_id"
+    t.boolean  "share",                                default: false
     t.text     "label_translations"
     t.text     "tip_translations"
     t.text     "content_translations"
-    t.boolean  "share",                                default: false
   end
 
   add_index "fe_elements", ["conditional_id"], name: "index_fe_elements_on_conditional_id", using: :btree

--- a/spec/models/fe/reference_question_spec.rb
+++ b/spec/models/fe/reference_question_spec.rb
@@ -14,4 +14,24 @@ describe Fe::ReferenceQuestion do
       expect(ref.ptemplate).to eq("fe/reference_abc")
     end
   end
+
+  it 'resets the question_sheet_id for references not created' do
+    qs1 = create(:question_sheet)
+    reference_question = create(:reference_question, related_question_sheet_id: qs1.id)
+    reference_sheet = create(:reference_sheet, question: reference_question)
+    expect(reference_sheet.question_sheet_id).to eq(qs1.id)
+
+    # change question sheet on ref element, the reference_sheet's question sheet should change
+    qs2 = create(:question_sheet)
+    expect(reference_sheet.status).to eq('created')
+    reference_question.update_attribute(:related_question_sheet_id, qs2.id)
+    expect(reference_sheet.reload.question_sheet_id).to eq(qs2.id)
+
+    # start the reference, then # change question sheet on ref element, the reference_sheet's
+    # question sheet should not change
+    reference_sheet.update_attribute(:status, 'started')
+    qs3 = create(:question_sheet)
+    reference_question.update_attribute(:related_question_sheet_id, qs3.id)
+    expect(reference_sheet.reload.question_sheet_id).to eq(qs2.id)
+  end
 end

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -133,4 +133,16 @@ describe Fe::ReferenceSheet do
       expect(reference.optional?).to be false
     end
   end
+
+  it 'sets the question_sheet_id' do
+    element = FactoryGirl.create(:reference_element, label: "Reference question here", required: true, related_question_sheet_id: 1)
+    application = FactoryGirl.create(:answer_sheet)
+    reference = FactoryGirl.create(:reference_sheet, applicant_answer_sheet: application, question: element)
+    expect(reference.question_sheet_id).to eq(1)
+  end
+
+  it 'starts out in created status' do
+    r = create(:reference_sheet)
+    expect(r.status).to eq('created')
+  end
 end


### PR DESCRIPTION
without this, any past completed apps were appearing blank because the
question sheet changed

Also fixes the starting reference sheet status not getting set properly.. fortunately most extending apps either had a db-level default or were implementing this own state machine