### PR TITLE
be more careful about resetting references

### DIFF
--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -171,7 +171,7 @@ module Fe
 
     # if the email address has changed, we have to trash the old reference answers
     def check_email_change
-      if !new_record? && changed.include?('email')
+      if !new_record? && !completed? && changed.include?('email')
         answers.destroy_all
         # Every time the email address changes, generate a new access_key
         generate_access_key

--- a/app/views/fe/questions/fe/_reference_question.html.erb
+++ b/app/views/fe/questions/fe/_reference_question.html.erb
@@ -8,15 +8,15 @@
   <ul class="questions level1">
     <li>
     <label for="<%= "name_#{reference.id}" %>" class="desc"><%= _('First Name') %></label>
-      <%= text_field_tag "reference[#{reference.id}][first_name]", reference.first_name, :class => "text #{css_class}", :id => "name_#{reference.id}", :readonly => !@answer_sheet.try(:can_change_references?), :disabled => !@answer_sheet.try(:can_change_references?) %>
+      <%= text_field_tag "reference[#{reference.id}][first_name]", reference.first_name, :class => "text #{css_class}", :id => "name_#{reference.id}", :readonly => reference.completed? || !@answer_sheet.try(:can_change_references?), :disabled => reference.completed? || !@answer_sheet.try(:can_change_references?) %>
     </li>
     <li>
     <label for="<%= "name_#{reference.id}" %>" class="desc"><%= _('Last Name') %> </label>
-      <%= text_field_tag "reference[#{reference.id}][last_name]", reference.last_name, :class => "text #{css_class}", :id => "name_#{reference.id}", :readonly => !@answer_sheet.try(:can_change_references?), :disabled => !@answer_sheet.try(:can_change_references?) %>
+      <%= text_field_tag "reference[#{reference.id}][last_name]", reference.last_name, :class => "text #{css_class}", :id => "name_#{reference.id}", :readonly => reference.completed? || !@answer_sheet.try(:can_change_references?), :disabled => reference.completed? || !@answer_sheet.try(:can_change_references?) %>
     </li>
     <li>
     <label for="<%= "name_#{reference.id}" %>" class="desc"><%= _('Relationship to You') %></label>
-      <%= text_field_tag "reference[#{reference.id}][relationship]", reference.relationship, :class => "text #{css_class}", :id => "name_#{reference.id}", :readonly => !@answer_sheet.try(:can_change_references?), :disabled => !@answer_sheet.try(:can_change_references?) %>
+      <%= text_field_tag "reference[#{reference.id}][relationship]", reference.relationship, :class => "text #{css_class}", :id => "name_#{reference.id}", :readonly => reference.completed? || !@answer_sheet.try(:can_change_references?), :disabled => reference.completed? || !@answer_sheet.try(:can_change_references?) %>
     </li>
     <li>
     <label for="<%= "email_#{reference.id}" %>" class="desc"><%= _('E-mail') %></label>
@@ -25,21 +25,26 @@
           <%= _('Please be aware that any changes to this email address after your reference has started filling out their form will cause their answers to be lost.') %>
         </div>
       <% end %>
-      <%= text_field_tag "reference[#{reference.id}][email]", reference.email, :class => "text #{email_css_class}", :id => "email_#{reference.id}", :readonly => !@answer_sheet.try(:can_change_references?), :disabled => !@answer_sheet.try(:can_change_references?) %>
+      <%= text_field_tag "reference[#{reference.id}][email]", reference.email, :class => "text #{email_css_class}", :id => "email_#{reference.id}", :readonly => reference.completed? || !@answer_sheet.try(:can_change_references?), :disabled => reference.completed? || !@answer_sheet.try(:can_change_references?) %>
     </li>
     <li>
     <label for="<%= "phone_#{reference.id}" %>" class="desc"><%= _('Phone') %></label>
-      <%= text_field_tag "reference[#{reference.id}][phone]", reference.phone, :class => "text #{phone_css_class}", :id => "phone_#{reference.id}", :readonly => !@answer_sheet.try(:can_change_references?), :disabled => !@answer_sheet.try(:can_change_references?) %>
+      <%= text_field_tag "reference[#{reference.id}][phone]", reference.phone, :class => "text #{phone_css_class}", :id => "phone_#{reference.id}", :readonly => reference.completed? || !@answer_sheet.try(:can_change_references?), :disabled => reference.completed? || !@answer_sheet.try(:can_change_references?) %>
     </li>
-    <li><p>
-      <%= _("An invitation will be sent to this reference when you submit your application.  If you would " \
-            "like to get a head start, please feel free to click 'Send Email Invitation' below.") %><br/>
-            <em><strong>
-      <%= _('If you already submitted your application and have returned to update your reference information - you must click "Send Email Invitation" after you ' \
-        'have edited the information in order for your reference to receive another email.') %>
-  </strong></em></p></li>
+    <li>
+      <% if reference.completed? %>
+        <p><strong><%= _("This reference is completed") %></strong></p>
+      <% else %>
+        <p>
+        <%= _("An invitation will be sent to this reference when you submit your application.  If you would " \
+              "like to get a head start, please feel free to click 'Send Email Invitation' below.") %><br/>
+              <em><strong>
+        <%= _('If you already submitted your application and have returned to update your reference information - you must click "Send Email Invitation" after you ' \
+          'have edited the information in order for your reference to receive another email.') %>
+    </strong></em></p></li>
 
-    <li><%= link_to(_('Send Email Invitation'), @answer_sheet ? send_reference_invite_fe_answer_sheet_path(@answer_sheet, :reference_id => reference.id) : '#', :class => 'reference_send_invite button no-left-margin') %>
-  <br/><%= _('Invitation last sent:') %> <span id="ref_last_sent_<%= reference.id %>"><% if reference.email_sent_at.nil? -%><%= _('Never') %><% else %><%= reference.email_sent_at.strftime("%Y-%m-%d @ %I:%M%p") %><% end %></span></li>
+      <li><%= link_to(_('Send Email Invitation'), @answer_sheet ? send_reference_invite_fe_answer_sheet_path(@answer_sheet, :reference_id => reference.id) : '#', :class => 'reference_send_invite button no-left-margin') %>
+    <br/><%= _('Invitation last sent:') %> <span id="ref_last_sent_<%= reference.id %>"><% if reference.email_sent_at.nil? -%><%= _('Never') %><% else %><%= reference.email_sent_at.strftime("%Y-%m-%d @ %I:%M%p") %><% end %></span></li>
+      <% end %>
   </ul>
 </div>


### PR DESCRIPTION
@twinge we've been having some bugs with ref answers disappearing in cap.  I know for sure the check_email_change was being triggered for those refs because the access key was changed compared to a backup, and the answers deleted.. but the emails are the same, so I'm not sure what happened there (it's possible they accidentally added a space then deleted it back to the original email or something like that).  This PR should help reduce this happening at least.

if the ref is completed, don't let it be changed

show the user when the reference is completed

add a db-level check for completed refs and don't delete the answers,
just to be sure