### PR TITLE
Use semicolon separate in conditional answer

### DIFF
--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -128,7 +128,7 @@ module Fe
       displayed_response = display_response(answer_sheet)
       (is_true(displayed_response) && is_true(conditional_answer)) ||
         (is_response_false(answer_sheet) && is_false(conditional_answer)) ||
-        (displayed_response == conditional_answer)
+        (responses(answer_sheet).include?(conditional_answer))
     end
 
     def is_response_false(answer_sheet)

--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -125,11 +125,10 @@ module Fe
     end
 
     def conditional_match(answer_sheet)
-      binding.pry
       displayed_response = display_response(answer_sheet)
       (is_true(displayed_response) && is_true(conditional_answer)) ||
         (is_response_false(answer_sheet) && is_false(conditional_answer)) ||
-        (responses(answer_sheet).include?(conditional_answer))
+        (responses(answer_sheet) && conditional_answers).any?
     end
 
     def is_response_false(answer_sheet)

--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -126,11 +126,11 @@ module Fe
 
     def conditional_match(answer_sheet)
       displayed_response = display_response(answer_sheet, ';')
-      responses_arr = display_response(answer_sheet).split(';')
+      responses_arr = displayed_response.split(';')
       (is_true(displayed_response) && is_true(conditional_answer)) ||
         (is_response_false(answer_sheet) && is_false(conditional_answer)) ||
         (responses_arr.empty? && conditional_answers.empty?) ||
-        (responses_arr && conditional_answers).any?
+        (responses_arr & conditional_answers).any?
     end
 
     def is_response_false(answer_sheet)

--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -125,6 +125,7 @@ module Fe
     end
 
     def conditional_match(answer_sheet)
+      binding.pry
       displayed_response = display_response(answer_sheet)
       (is_true(displayed_response) && is_true(conditional_answer)) ||
         (is_response_false(answer_sheet) && is_false(conditional_answer)) ||

--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -105,7 +105,7 @@ module Fe
       end
     end
 
-    def display_response(app=nil)
+    def display_response(app = nil, joiner = ', ')
       r = responses(app)
       r.reject! {|a| a.class == Answer && a.value.blank?}
       if r.blank?
@@ -120,15 +120,17 @@ module Fe
       elsif self.style == 'acceptance'
         "Accepted"  # if not blank, it's accepted
       else
-        r.compact.join(", ")
+        r.compact.join(joiner)
       end
     end
 
     def conditional_match(answer_sheet)
-      displayed_response = display_response(answer_sheet)
+      displayed_response = display_response(answer_sheet, ';')
+      responses_arr = display_response(answer_sheet).split(';')
       (is_true(displayed_response) && is_true(conditional_answer)) ||
         (is_response_false(answer_sheet) && is_false(conditional_answer)) ||
-        (responses(answer_sheet) && conditional_answers).any?
+        (responses_arr.empty? && conditional_answers.empty?) ||
+        (responses_arr && conditional_answers).any?
     end
 
     def is_response_false(answer_sheet)

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -223,7 +223,7 @@ module Fe
     def conditional_match(answer_sheet)
       displayed_response = display_response(answer_sheet)
       return false unless displayed_response && conditional_answer
-      conditional_answer.include?(display_response)
+      conditional_answers.include?(displayed_response)
     end
 
     def self.max_label_length

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -219,7 +219,7 @@ module Fe
     def conditional_match(answer_sheet)
       displayed_response = display_response(answer_sheet)
       return false unless displayed_response && conditional_answer
-      (displayed_response.split(',') & conditional_answer.split(',')).length > 0
+      (displayed_response.split(';') & conditional_answer.split(',')).length > 0
     end
 
     def self.max_label_length

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -216,10 +216,14 @@ module Fe
       (self.is_a?(Fe::Question) || self.is_a?(Fe::QuestionGrid) || self.is_a?(Fe::QuestionGridWithTotal))
     end
 
+    def conditional_answers
+      conditional_answer.split(';').collect(&:strip)
+    end
+
     def conditional_match(answer_sheet)
       displayed_response = display_response(answer_sheet)
       return false unless displayed_response && conditional_answer
-      (displayed_response.split(';') & conditional_answer.split(',')).length > 0
+      conditional_answer.include?(display_response)
     end
 
     def self.max_label_length

--- a/app/views/fe/admin/panels/_advanced_options.html.erb
+++ b/app/views/fe/admin/panels/_advanced_options.html.erb
@@ -17,7 +17,7 @@
     <div class='future_answer' style='display:none'>
       What answer should show the element or page? <%= f.text_field "conditional_answer" %>
       <br/>
-      Enter multiple answers separated by commas to match using an OR condition.  Ex: "Option A, Option B" will match either "Option A" or "Option B" answers
+      Enter multiple answers separated by semi-colon to match using an OR condition.  Ex: "Option A; Option B" will match either "Option A" or "Option B" answers
     </div>
     <div class='future_target' style='display:none'>
       <label>Should it show the next element or a page further down the application?</label>

--- a/db/migrate/20151021181928_switch_conditional_answer_separator_to_semicolon.rb
+++ b/db/migrate/20151021181928_switch_conditional_answer_separator_to_semicolon.rb
@@ -1,0 +1,7 @@
+class SwitchConditionalAnswerSeparatorToSemicolon < ActiveRecord::Migration
+  def change
+    Fe::Element.where("conditional_answer IS NOT NULL AND conditional_answer != ''").each do |e|
+      e.update_column :conditional_answer, e.conditional_answer.gsub(',', ';')
+    end
+  end
+end

--- a/spec/models/fe/choice_field_spec.rb
+++ b/spec/models/fe/choice_field_spec.rb
@@ -58,9 +58,9 @@ describe Fe::ChoiceField do
       e = create(:choice_field_element, conditional_answer: 'a;b', style: 'drop-down')
       qs.pages << create(:page)
       qs.pages.reload.first.elements << e
-      a = create(:answer, question_id: e, value: 'a', answer_sheet_id: app.id, question_id: e.id)
-      a = create(:answer, question_id: e, value: 'b', answer_sheet_id: app.id, question_id: e.id)
-      a = create(:answer, question_id: e, value: 'c', answer_sheet_id: app.id, question_id: e.id)
+      a = create(:answer, question: e, value: 'a', answer_sheet_id: app.id)
+      a = create(:answer, question: e, value: 'b', answer_sheet_id: app.id)
+      a = create(:answer, question: e, value: 'c', answer_sheet_id: app.id)
       expect(e.conditional_match(app)).to be true
     end
     it 'returns false if any of none of the options match conditional_answer' do
@@ -70,8 +70,8 @@ describe Fe::ChoiceField do
       e = create(:choice_field_element, conditional_answer: 'a;b', style: 'drop-down')
       qs.pages << create(:page)
       qs.pages.reload.first.elements << e
-      a = create(:answer, question_id: e, value: 'c', answer_sheet_id: app.id, question_id: e.id)
-      a = create(:answer, question_id: e, value: 'd', answer_sheet_id: app.id, question_id: e.id)
+      a = create(:answer, question: e, value: 'c', answer_sheet_id: app.id)
+      a = create(:answer, question: e, value: 'd', answer_sheet_id: app.id)
       expect(e.conditional_match(app)).to be true
     end
     it 'returns true if the conditional_answer is empty and no options are selected' do
@@ -81,6 +81,17 @@ describe Fe::ChoiceField do
       e = create(:choice_field_element, conditional_answer: '', style: 'drop-down')
       qs.pages << create(:page)
       qs.pages.reload.first.elements << e
+      expect(e.conditional_match(app)).to be true
+    end
+    it 'returns true regardless of whitespace separating conditional answers' do
+      qs = create(:question_sheet)
+      app = create(:application)
+      app.question_sheets << qs
+      e = create(:choice_field_element, conditional_answer: "a; b\n", style: 'drop-down')
+      qs.pages << create(:page)
+      qs.pages.reload.first.elements << e
+      a = create(:answer, question: e, value: 'c', answer_sheet_id: app.id)
+      a = create(:answer, question: e, value: 'd', answer_sheet_id: app.id)
       expect(e.conditional_match(app)).to be true
     end
   end

--- a/spec/models/fe/choice_field_spec.rb
+++ b/spec/models/fe/choice_field_spec.rb
@@ -58,7 +58,9 @@ describe Fe::ChoiceField do
       e = create(:choice_field_element, conditional_answer: 'a;b', style: 'drop-down')
       qs.pages << create(:page)
       qs.pages.reload.first.elements << e
-      a = create(:answer, question_id: e, value: 'a;b;c', answer_sheet_id: app.id, question_id: e.id)
+      a = create(:answer, question_id: e, value: 'a', answer_sheet_id: app.id, question_id: e.id)
+      a = create(:answer, question_id: e, value: 'b', answer_sheet_id: app.id, question_id: e.id)
+      a = create(:answer, question_id: e, value: 'c', answer_sheet_id: app.id, question_id: e.id)
       expect(e.conditional_match(app)).to be true
     end
     it 'returns false if any of none of the options match conditional_answer' do
@@ -68,7 +70,17 @@ describe Fe::ChoiceField do
       e = create(:choice_field_element, conditional_answer: 'a;b', style: 'drop-down')
       qs.pages << create(:page)
       qs.pages.reload.first.elements << e
-      a = create(:answer, question_id: e, value: 'c;d', answer_sheet_id: app.id, question_id: e.id)
+      a = create(:answer, question_id: e, value: 'c', answer_sheet_id: app.id, question_id: e.id)
+      a = create(:answer, question_id: e, value: 'd', answer_sheet_id: app.id, question_id: e.id)
+      expect(e.conditional_match(app)).to be true
+    end
+    it 'returns true if the conditional_answer is empty and no options are selected' do
+      qs = create(:question_sheet)
+      app = create(:application)
+      app.question_sheets << qs
+      e = create(:choice_field_element, conditional_answer: '', style: 'drop-down')
+      qs.pages << create(:page)
+      qs.pages.reload.first.elements << e
       expect(e.conditional_match(app)).to be true
     end
   end

--- a/spec/models/fe/choice_field_spec.rb
+++ b/spec/models/fe/choice_field_spec.rb
@@ -50,5 +50,12 @@ describe Fe::ChoiceField do
     end
   end
 
-  # TODO: test conditional_match
+  context '#conditional_match' do
+    it 'returns true if any of the options are selected' do
+      app = create(:application)
+      e = create(:choice_field_element, conditional_answer: 'a;b')
+      a = create(:answer, question_id: e, value: 'a;b;c')
+      expect(e.conditional_match).to be true
+    end
+  end
 end

--- a/spec/models/fe/choice_field_spec.rb
+++ b/spec/models/fe/choice_field_spec.rb
@@ -49,4 +49,6 @@ describe Fe::ChoiceField do
       expect(Fe::ChoiceField.new(style: 'drop-down', content: "1;A\n0;B").choices).to eq([["A","1"],["B","0"]])
     end
   end
+
+  # TODO: test conditional_match
 end

--- a/spec/models/fe/choice_field_spec.rb
+++ b/spec/models/fe/choice_field_spec.rb
@@ -51,7 +51,7 @@ describe Fe::ChoiceField do
   end
 
   context '#conditional_match' do
-    it 'returns true if any of the options are selected' do
+    it 'returns true if any of the options from conditional_answer are selected' do
       qs = create(:question_sheet)
       app = create(:application)
       app.question_sheets << qs
@@ -59,6 +59,16 @@ describe Fe::ChoiceField do
       qs.pages << create(:page)
       qs.pages.reload.first.elements << e
       a = create(:answer, question_id: e, value: 'a;b;c', answer_sheet_id: app.id, question_id: e.id)
+      expect(e.conditional_match(app)).to be true
+    end
+    it 'returns false if any of none of the options match conditional_answer' do
+      qs = create(:question_sheet)
+      app = create(:application)
+      app.question_sheets << qs
+      e = create(:choice_field_element, conditional_answer: 'a;b', style: 'drop-down')
+      qs.pages << create(:page)
+      qs.pages.reload.first.elements << e
+      a = create(:answer, question_id: e, value: 'c;d', answer_sheet_id: app.id, question_id: e.id)
       expect(e.conditional_match(app)).to be true
     end
   end

--- a/spec/models/fe/choice_field_spec.rb
+++ b/spec/models/fe/choice_field_spec.rb
@@ -52,10 +52,14 @@ describe Fe::ChoiceField do
 
   context '#conditional_match' do
     it 'returns true if any of the options are selected' do
+      qs = create(:question_sheet)
       app = create(:application)
-      e = create(:choice_field_element, conditional_answer: 'a;b')
-      a = create(:answer, question_id: e, value: 'a;b;c')
-      expect(e.conditional_match).to be true
+      app.question_sheets << qs
+      e = create(:choice_field_element, conditional_answer: 'a;b', style: 'drop-down')
+      qs.pages << create(:page)
+      qs.pages.reload.first.elements << e
+      a = create(:answer, question_id: e, value: 'a;b;c', answer_sheet_id: app.id, question_id: e.id)
+      expect(e.conditional_match(app)).to be true
     end
   end
 end

--- a/spec/models/fe/choice_field_spec.rb
+++ b/spec/models/fe/choice_field_spec.rb
@@ -72,7 +72,7 @@ describe Fe::ChoiceField do
       qs.pages.reload.first.elements << e
       a = create(:answer, question: e, value: 'c', answer_sheet_id: app.id)
       a = create(:answer, question: e, value: 'd', answer_sheet_id: app.id)
-      expect(e.conditional_match(app)).to be true
+      expect(e.conditional_match(app)).to be false
     end
     it 'returns true if the conditional_answer is empty and no options are selected' do
       qs = create(:question_sheet)
@@ -90,7 +90,7 @@ describe Fe::ChoiceField do
       e = create(:choice_field_element, conditional_answer: "a; b\n", style: 'drop-down')
       qs.pages << create(:page)
       qs.pages.reload.first.elements << e
-      a = create(:answer, question: e, value: 'c', answer_sheet_id: app.id)
+      a = create(:answer, question: e, value: 'a', answer_sheet_id: app.id)
       a = create(:answer, question: e, value: 'd', answer_sheet_id: app.id)
       expect(e.conditional_match(app)).to be true
     end

--- a/spec/models/fe/text_field_spec.rb
+++ b/spec/models/fe/text_field_spec.rb
@@ -14,4 +14,6 @@ describe Fe::TextField do
       expect(text_field.ptemplate).to eq("fe/text_area_field")
     end 
   end
+
+  # TODO: test conditional_match on a text field
 end

--- a/spec/models/fe/text_field_spec.rb
+++ b/spec/models/fe/text_field_spec.rb
@@ -15,5 +15,25 @@ describe Fe::TextField do
     end 
   end
 
-  # TODO: test conditional_match on a text field
+  it 'should match conditional_match' do
+    qs = create(:question_sheet)
+    app = create(:application)
+    app.question_sheets << qs
+    e = create(:text_field_element, conditional_answer: 'a;b', style: 'drop-down')
+    qs.pages << create(:page)
+    qs.pages.reload.first.elements << e
+    a = create(:answer, question_id: e, value: 'b', answer_sheet_id: app.id, question_id: e.id)
+    expect(e.conditional_match(app)).to be true
+  end
+
+  it "should not match conditional_match if the answer doesn't match" do
+    qs = create(:question_sheet)
+    app = create(:application)
+    app.question_sheets << qs
+    e = create(:text_field_element, conditional_answer: 'a;b', style: 'drop-down')
+    qs.pages << create(:page)
+    qs.pages.reload.first.elements << e
+    a = create(:answer, question_id: e, value: 'c', answer_sheet_id: app.id, question_id: e.id)
+    expect(e.conditional_match(app)).to_not be true
+  end
 end


### PR DESCRIPTION
@twinge 

use ; instead of , in separating conditional_answer
since a comma is much more likely to be used in an answer, when matching
multiple possible answers in the conditional answer functionality, use ;
instead

fix matching conditional answers in checkbox questions, so that if any checked option matches any conditional answer it will match