### PR TITLE
use has_answer? in conditional_match

### DIFF
--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -105,7 +105,7 @@ module Fe
       end
     end
 
-    def display_response(app = nil, joiner = ', ')
+    def display_response(app = nil, _humanize = false)
       r = responses(app)
       if r.blank?
         ""
@@ -119,7 +119,7 @@ module Fe
       elsif self.style == 'acceptance'
         "Accepted"  # if not blank, it's accepted
       else
-        r.compact.join(joiner)
+        r.compact.join(', ')
       end
     end
 

--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -44,19 +44,19 @@ module Fe
       return retVal
     end
 
-    def has_answer?(choice, app)
-      responses(app).each do |r|   # loop through Answers
-                                   # legacy field type choices may be int or tinyint
-                                   # raise r.inspect + ' - ' + choice.inspect if id == 1137 && r != 1
-                                   # r = r.to_s
-        return true if  case true
-                          when is_true(r) then is_true(choice)
-                          when is_false(r) then is_false(choice)
-                          else
-                            r.to_s == choice.to_s
-                        end
+    # choices can be an array, in which case any match returns true
+    def has_answer?(choice, answer_sheet)
+      if choice.is_a?(Array)
+        return choice.any? { |c| 
+          has_answer?(c, answer_sheet)
+        }
       end
-      false
+
+      responses(answer_sheet).any? { |r|
+        is_true(r) && is_true(choice) ||
+        is_false(r) && is_false(choice) ||
+        r.to_s.strip == choice.to_s.strip
+      }
     end
 
     # which view to render this element?
@@ -107,7 +107,6 @@ module Fe
 
     def display_response(app = nil, joiner = ', ')
       r = responses(app)
-      r.reject! {|a| a.class == Answer && a.value.blank?}
       if r.blank?
         ""
       elsif self.style == 'yes-no'
@@ -125,12 +124,8 @@ module Fe
     end
 
     def conditional_match(answer_sheet)
-      displayed_response = display_response(answer_sheet, ';')
-      responses_arr = displayed_response.split(';')
-      (is_true(displayed_response) && is_true(conditional_answer)) ||
-        (is_response_false(answer_sheet) && is_false(conditional_answer)) ||
-        (responses_arr.empty? && conditional_answers.empty?) ||
-        (responses_arr & conditional_answers).any?
+      has_answer?(conditional_answers, answer_sheet) || 
+        (responses(answer_sheet).empty? && conditional_answers.empty?)
     end
 
     def is_response_false(answer_sheet)

--- a/app/models/fe/date_field.rb
+++ b/app/models/fe/date_field.rb
@@ -29,7 +29,7 @@ module Fe
       r
     end
 
-    def display_response(answer_sheet = nil)
+    def display_response(answer_sheet = nil, humanize = false)
       return format_date_response(answer_sheet)
     end
 

--- a/app/models/fe/date_field.rb
+++ b/app/models/fe/date_field.rb
@@ -29,7 +29,7 @@ module Fe
       r
     end
 
-    def display_response(answer_sheet = nil, humanize = false)
+    def display_response(answer_sheet = nil, _humanize = false)
       return format_date_response(answer_sheet)
     end
 

--- a/app/models/fe/question.rb
+++ b/app/models/fe/question.rb
@@ -126,7 +126,7 @@ module Fe
       responses(answer_sheet).first.to_s
     end
 
-    def display_response(answer_sheet)
+    def display_response(answer_sheet, humanize = false)
       r = responses(answer_sheet)
       if r.blank?
         ""
@@ -147,8 +147,9 @@ module Fe
           [eval("obj." + attribute_name)]
         end
       else
-        #answer_sheet.answers_by_question[id] || []
-        Fe::Answer.where(:answer_sheet_id => answer_sheet.id, :question_id => self.id).to_a
+        answers = Fe::Answer.where(answer_sheet_id: answer_sheet.id, question_id: self.id)
+        answers = answers.where("value IS NOT NULL AND value != ''")
+        answers.to_a
       end
     end
 

--- a/app/models/fe/question.rb
+++ b/app/models/fe/question.rb
@@ -126,7 +126,7 @@ module Fe
       responses(answer_sheet).first.to_s
     end
 
-    def display_response(answer_sheet, humanize = false)
+    def display_response(answer_sheet, _humanize = false)
       r = responses(answer_sheet)
       if r.blank?
         ""

--- a/app/models/fe/question.rb
+++ b/app/models/fe/question.rb
@@ -126,6 +126,13 @@ module Fe
       responses(answer_sheet).first.to_s
     end
 
+    # _humanize can be used in overridden display_response
+    # implementations to produce a string for human viewing
+    # This can be useful for choice fields that use object_name
+    # and attribute_name to store an ID value, juch as campus_id.
+    # When an evaluator views the application, they should see
+    # the campus name, so _humanize can be checked in that
+    # case to output the campus name and not just the ID.
     def display_response(answer_sheet, _humanize = false)
       r = responses(answer_sheet)
       if r.blank?

--- a/app/models/fe/reference_question.rb
+++ b/app/models/fe/reference_question.rb
@@ -22,7 +22,7 @@ module Fe
       end
     end
 
-    def display_response(app=nil)
+    def display_response(app = nil, humanize = false)
       response(app).to_s
     end
 


### PR DESCRIPTION
@twinge 

I didn't like how I was doing the display_response stuff with the joiner and how it was being used in conditional_match.  It seems strange in conditional_match how it was using desplay_response to join the answers together, then split again on ";".  Also, if display_response rejects empty answers, I think we should just do that in responses, and then I can use the responses array in conditional_match (since empty answers are stripped out.  That was the only reason I was using display_response instead of has_answer?).  Using has_answer? is nice because it's already in FE so conditional_match can be simplified a lot.

Also cleaned up has_answer? a bit since it looks pretty old, and made it possible to check for multiple answers at once by passing in an array.

display_response also has a humanize parameter that will make it easier for me to handle choice fields that store ids as answers.  Because of the concerns modules and extending classes, I was having problems overriding display_response.. sometimes super() was going to the Fe::Question implementation instead of the concern implementation.  And the joiner optional parameter was making it even more complicated to try to add a third parameter (humanize).