### PR TITLE
fix filtering in answer sheet show

### DIFF
--- a/app/controllers/fe/concerns/answer_sheets_controller_concern.rb
+++ b/app/controllers/fe/concerns/answer_sheets_controller_concern.rb
@@ -48,7 +48,7 @@ module Fe::AnswerSheetsControllerConcern
     @elements = @question_sheet.pages.collect {|p| p.elements.includes(:pages).order("#{pf}pages.number,#{pf}page_elements.position").all}.flatten
     questions = Fe::QuestionSet.new(@elements, @answer_sheet)
     questions.set_filter(get_filter)
-    @elements = Fe::QuestionSet.new(@elements, @answer_sheet).elements.group_by{ |e| e.pages.first }
+    @elements = questions.elements.group_by{ |e| e.pages.first }
   end
 
   def send_reference_invite(reference = nil)

--- a/spec/controllers/fe/answer_pages_controller_spec.rb
+++ b/spec/controllers/fe/answer_pages_controller_spec.rb
@@ -2,41 +2,43 @@ require 'rails_helper'
 
 describe Fe::AnswerPagesController, type: :controller do
   context '#edit' do
+    let(:answer_sheet) { create(:answer_sheet) }
+    let(:page) { create(:page) }
+
     it 'should work' do
-      answer_sheet = create(:answer_sheet)
-      page = create(:page)
       question_sheet = page.question_sheet
       create(:answer_sheet_question_sheet, answer_sheet: answer_sheet, question_sheet: question_sheet)
       get :edit, id: page.id, answer_sheet_id: answer_sheet.id
       expect(response).to render_template('fe/answer_pages/_answer_page')
     end
-    it 'should filter out elements' do
-      answer_sheet = create(:answer_sheet)
-      page = create(:page)
-      el_confidential = create(:text_field_element, is_confidential: true)
-      el_visible = create(:text_field_element, is_confidential: false)
-      page.elements << el_confidential << el_visible
-      question_sheet = page.question_sheet
-      create(:answer_sheet_question_sheet, answer_sheet: answer_sheet, question_sheet: question_sheet)
-      allow_any_instance_of(Fe::AnswerPagesController).to receive(:get_filter).and_return(filter_default: :show, filter: [ :is_confidential ])
-      get :edit, id: page.id, answer_sheet_id: answer_sheet.id
-      expect(assigns(:elements)).to_not include(el_confidential)
-      expect(assigns(:elements)).to include(el_visible)
-    end
-    it 'should filter in elements' do
-      answer_sheet = create(:answer_sheet)
-      page = create(:page)
-      el_confidential = create(:text_field_element, is_confidential: true)
-      el_visible = create(:text_field_element, is_confidential: false)
-      page.elements << el_confidential << el_visible
-      question_sheet = page.question_sheet
-      create(:answer_sheet_question_sheet, answer_sheet: answer_sheet, question_sheet: question_sheet)
-      allow_any_instance_of(Fe::AnswerPagesController).to receive(:get_filter).and_return(filter_default: :hide, filter: [ :is_confidential ])
-      get :edit, id: page.id, answer_sheet_id: answer_sheet.id
-      expect(assigns(:elements)).to include(el_confidential)
-      expect(assigns(:elements)).to_not include(el_visible)
+    context 'filtering' do
+      let(:el_confidential) { create(:text_field_element, is_confidential: true) }
+      let(:el_visible) { create(:text_field_element, is_confidential: false) }
+      let(:el_visible2) { create(:text_field_element, is_confidential: false) }
+
+      before do
+        page.elements << el_confidential << el_visible << el_visible2
+        question_sheet = page.question_sheet
+        create(:answer_sheet_question_sheet, answer_sheet: answer_sheet, question_sheet: question_sheet)
+      end
+
+      it 'should filter out elements' do
+        allow_any_instance_of(Fe::AnswerPagesController).to receive(:get_filter).and_return(filter_default: :show, filter: [ :is_confidential ])
+        get :edit, id: page.id, answer_sheet_id: answer_sheet.id
+        expect(assigns(:elements)).to_not include(el_confidential)
+        expect(assigns(:elements)).to include(el_visible)
+        expect(assigns(:elements)).to include(el_visible2)
+      end
+      it 'should filter in elements' do
+        allow_any_instance_of(Fe::AnswerPagesController).to receive(:get_filter).and_return(filter_default: :hide, filter: [ :is_confidential ])
+        get :edit, id: page.id, answer_sheet_id: answer_sheet.id
+        expect(assigns(:elements)).to include(el_confidential)
+        expect(assigns(:elements)).to_not include(el_visible)
+        expect(assigns(:elements)).to_not include(el_visible2)
+      end
     end
   end
+
   context '#update' do
     it 'should work' do
       answer_sheet = create(:answer_sheet)


### PR DESCRIPTION
@twinge 

the filtered elements was getting overwritten

also cleans up answer_pages specs a bit