### PR TITLE
make slug unique per question sheet

### DIFF
--- a/spec/models/fe/question_spec.rb
+++ b/spec/models/fe/question_spec.rb
@@ -18,4 +18,29 @@ describe Fe::Question do
     end
   end
   
+  context 'slug' do
+    let(:qs) { create(:question_sheet_with_pages) }
+    let(:page) { qs.pages.first }
+    let(:qs2) { create(:question_sheet_with_pages) }
+    let(:page2) { qs2.pages.first }
+    let(:e1) { create(:text_field_element, slug: 'test') }
+    let(:e2) { create(:text_field_element) }
+
+    before do
+      e1.pages << page
+    end
+
+    it "doesn't let the same slug be used in the question sheet" do
+      e2.pages << page
+      e2.slug = 'test'
+      e2.save
+      expect(e2.errors.full_messages.join(', ')).to include('Slug must be unique (within the question sheet)')
+    end
+    it "lets two elements with the same slug save on different sheets" do
+      e2.pages << page2
+      e2.slug = 'test'
+      expect(e2.save).to be true
+    end
+  end
+
 end


### PR DESCRIPTION
@twinge Slug is useful to identify questions, for exaple the new staff training
preference.  It can be used to pull or set the answer outside the form
engine.  But for this to be useful it needs to be available for use on
different question sheets using the same slug.