### PR TITLE
Handle hidden? if there's no page

### DIFF
--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -140,7 +140,7 @@ module Fe
     # use page if it's passed in, otherwise it will revert to the first page in answer_sheet
     def hidden?(answer_sheet = nil, page = nil)
       page ||= pages_on.detect{ |p| answer_sheet.question_sheets.include?(p.question_sheet) }
-      return true if page.hidden?(answer_sheet)
+      return true if !page || page.hidden?(answer_sheet)
       return page.all_hidden_elements(answer_sheet).include?(self)
     end
 


### PR DESCRIPTION
SMT specs were balking at this because there was a scenario where the page couldn't be found.