### PR TITLE
languify state chooser

### DIFF
--- a/app/models/fe/state_chooser.rb
+++ b/app/models/fe/state_chooser.rb
@@ -3,8 +3,8 @@ require 'carmen'
 # - drop down of states
 module Fe
   class StateChooser < Question
-    def choices(country = 'US')
-      @states = Carmen.states(country)
+    def choices(locale = nil, country = 'US')
+      @states = _(Carmen.states(country))
     end
   end
 end

--- a/app/views/fe/questions/fe/_state_chooser.html.erb
+++ b/app/views/fe/questions/fe/_state_chooser.html.erb
@@ -1,7 +1,7 @@
 <% locked = state_chooser.locked?(params, @answer_sheet, @presenter) %>
 <%= select_tag "answers[#{state_chooser.id}]",
-    options_for_select(["", ['Not Listed','N/A']] + state_chooser.choices, [state_chooser.response(@answer_sheet).to_s]),
-    :class => 'select ' + state_chooser.validation_class(@answer_sheet),
-    :id => dom_id(state_chooser), 
-    :disabled => locked,
-    :readonly => locked %>
+    options_for_select(["", ['Not Listed','N/A']] + state_chooser.choices(session[:locale]), [state_chooser.response(@answer_sheet).to_s]),
+      class: 'select ' + state_chooser.validation_class(@answer_sheet),
+      id: dom_id(state_chooser),
+      disabled: locked,
+      readonly: locked %>


### PR DESCRIPTION
@twinge the state chooser needs to reflect the other elements with a choices
method and put locale as the first parameter; then we might as well
translate the states too

Btw calling _ on an array seems to work as expected: 

cap(dev)> _(['a','b'])
=> ["a", "b"]
