### PR TITLE
stop all the empty string answers

### DIFF
--- a/app/models/fe/question.rb
+++ b/app/models/fe/question.rb
@@ -152,7 +152,7 @@ module Fe
           [eval("obj." + attribute_name)]
         end
       else
-        answers = Fe::Answer.where(answer_sheet_id: answer_sheet.id, question_id: self.id)
+        answers = sheet_answers.where(answer_sheet: answer_sheet)
         answers = answers.where("value IS NOT NULL AND value != ''")
         answers.to_a
       end
@@ -186,7 +186,7 @@ module Fe
         #   raise object_name.inspect + ' == ' + attribute_name.inspect
         # end
       else
-        @answers ||= []
+        @answers ||= sheet_answers.to_a
         @mark_for_destroy ||= []
         # go through existing answers (in reverse order, as we delete)
         (@answers.length - 1).downto(0) do |index|
@@ -245,13 +245,9 @@ module Fe
 
     # has any sort of non-empty response?
     def has_response?(answer_sheet = nil)
-      if answer_sheet.present?
-        answers = responses(answer_sheet)
-      else
-        answers = Fe::Answer.where(:question_id => self.id)
-      end
+      answers = answer_sheet.present? ? responses(answer_sheet) : sheet_answers
       return false if answers.length == 0
-      answers.each do |answer|   # loop through Answers
+      answers.each do |answer|
         value = answer.is_a?(Fe::Answer) ? answer.value : answer
         return true if (value.is_a?(FalseClass) && value === false) || value.present?
       end

--- a/app/models/fe/question_set.rb
+++ b/app/models/fe/question_set.rb
@@ -9,20 +9,12 @@ module Fe
     def initialize(elements, answer_sheet)
       @elements = elements
       @answer_sheet = answer_sheet
-
       @questions = elements.select { |e| e.question? }
-
-      # answers = @answer_sheet.answers_by_question
-
-      @questions.each do |question|
-        question.answers = question.responses(answer_sheet) #answers[question.id]
-      end
-      @questions
     end
 
     # update with responses from form
     def post(params, answer_sheet)
-      questions_indexed = @questions.index_by {|q| q.id}
+      questions_indexed = @questions.index_by(&:id)
 
       # loop over form values
       params ||= {}

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -6,3 +6,5 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w(fe/fe.public.js)
+Rails.application.config.assets.precompile += %w(fe/ajax-loader.gif fe/status.gif)

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -4,7 +4,8 @@
 Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+
+# javascripts
 Rails.application.config.assets.precompile += %w(fe/fe.public.js)
-Rails.application.config.assets.precompile += %w(fe/ajax-loader.gif fe/status.gif)
+# images
+Rails.application.config.assets.precompile += %w(fe/ajax-loader.gif fe/status.gif fe/icons/question-balloon.png)

--- a/spec/models/fe/question_set_spec.rb
+++ b/spec/models/fe/question_set_spec.rb
@@ -4,14 +4,13 @@ describe Fe::QuestionSet do
   let(:app) { create(:application) }
 
   before do
-    answer_sheet = create(:answer_sheet)
-    page = create(:page)
+    @page = create(:page)
     @el_confidential = create(:text_field_element, label: 'conf1', is_confidential: true, share: true)
     @el_visible = create(:text_field_element, label: 'vis1', is_confidential: false, share: false)
     @el_confidential2 = create(:text_field_element, label: 'conf2', is_confidential: true, share: true)
     @el_visible2 = create(:text_field_element, label: 'vis2', is_confidential: false, share: true)
-    page.elements << @el_confidential << @el_visible << @el_confidential2 << @el_visible2
-    @question_set = Fe::QuestionSet.new(page.elements, app)
+    @page.elements << @el_confidential << @el_visible << @el_confidential2 << @el_visible2
+    @question_set = Fe::QuestionSet.new(@page.elements, app)
   end
 
   it 'should filter default show' do
@@ -28,5 +27,50 @@ describe Fe::QuestionSet do
     # filter methods)
     @question_set.set_filter(filter_default: :hide, filter: [ :is_confidential, :share ])
     expect(@question_set.elements).to eq([@el_confidential, @el_confidential2])
+  end
+
+  context 'saving answers (#post then #save)' do
+    it 'saves a new value' do
+      @question_set.post({ @el_visible.id => 'a text response' }, app)
+      @question_set.save
+      expect(Fe::Answer.count).to eq(1)
+      expect(Fe::Answer.first.value).to eq('a text response')
+      expect(Fe::Answer.first.answer_sheet_id).to eq(app.id)
+      expect(Fe::Answer.first.question_id).to eq(@el_visible.id)
+    end
+    it 'replaces an existing answer' do
+      create(:answer, value: 'a text response', answer_sheet: app, question: @el_visible)
+      @question_set = Fe::QuestionSet.new(@page.elements, app) # need this to reload the elements in the question set to get the new answer
+      @question_set.post({ @el_visible.id => 'an updated response' }, app)
+      @question_set.save
+      expect(Fe::Answer.count).to eq(1)
+      expect(Fe::Answer.first.value).to eq('an updated response')
+      expect(Fe::Answer.first.answer_sheet_id).to eq(app.id)
+      expect(Fe::Answer.first.question_id).to eq(@el_visible.id)
+    end
+    it "doesn't save empty strings continually" do
+      create(:answer, value: '', answer_sheet: app, question: @el_visible)
+      @question_set = Fe::QuestionSet.new(@page.elements, app) # need this to reload the elements in the question set to get the new answer
+      @question_set.post({ @el_visible.id => '' }, app)
+      @question_set.save
+      expect(Fe::Answer.count).to eq(1)
+      expect(Fe::Answer.first.value).to eq('')
+      expect(Fe::Answer.first.answer_sheet_id).to eq(app.id)
+      expect(Fe::Answer.first.question_id).to eq(@el_visible.id)
+    end
+    it 'saves multiple values' do
+      @el_visible.update(kind: 'Fe::ChoiceField', style: 'checkbox', content: "choice 1\nchoice 2")
+      create(:answer, value: 'choice 1', answer_sheet: app, question: @el_visible)
+      @question_set = Fe::QuestionSet.new(@page.elements, app) # need this to reload the elements in the question set to get the new answer
+      @question_set.post({ @el_visible.id => { '0' => 'choice 1', '1' => 'choice 2' } }, app)
+      @question_set.save
+      expect(Fe::Answer.count).to eq(2)
+      expect(Fe::Answer.first.value).to eq('choice 1')
+      expect(Fe::Answer.first.answer_sheet_id).to eq(app.id)
+      expect(Fe::Answer.first.question_id).to eq(@el_visible.id)
+      expect(Fe::Answer.second.value).to eq('choice 2')
+      expect(Fe::Answer.second.answer_sheet_id).to eq(app.id)
+      expect(Fe::Answer.second.question_id).to eq(@el_visible.id)
+    end
   end
 end

--- a/spec/models/fe/question_set_spec.rb
+++ b/spec/models/fe/question_set_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Fe::QuestionSet do
   let(:app) { create(:application) }
+  let(:app2) { create(:application) }
 
   before do
     @page = create(:page)
@@ -70,6 +71,24 @@ describe Fe::QuestionSet do
       expect(Fe::Answer.first.question_id).to eq(@el_visible.id)
       expect(Fe::Answer.second.value).to eq('choice 2')
       expect(Fe::Answer.second.answer_sheet_id).to eq(app.id)
+      expect(Fe::Answer.second.question_id).to eq(@el_visible.id)
+    end
+    it 'saves the same value for different answer sheets' do
+      @el_visible.update(kind: 'Fe::ChoiceField', style: 'checkbox', content: "choice 1\nchoice 2")
+      @question_set = Fe::QuestionSet.new(@page.elements, app) # need this to reload the elements in the question set to get the new answer
+      @question_set.post({ @el_visible.id => { '0' => 'choice 1' } }, app)
+      @question_set.save
+      @question_set = Fe::QuestionSet.new(@page.elements, app2) # need this to save answers to app2
+      $b = true
+      @question_set.post({ @el_visible.id => { '0' => 'choice 1' } }, app2)
+      @question_set.save
+      $b = false
+      expect(Fe::Answer.count).to eq(2)
+      expect(Fe::Answer.first.value).to eq('choice 1')
+      expect(Fe::Answer.first.answer_sheet_id).to eq(app.id)
+      expect(Fe::Answer.first.question_id).to eq(@el_visible.id)
+      expect(Fe::Answer.second.value).to eq('choice 1')
+      expect(Fe::Answer.second.answer_sheet_id).to eq(app2.id)
       expect(Fe::Answer.second.question_id).to eq(@el_visible.id)
     end
   end

--- a/spec/models/fe/question_spec.rb
+++ b/spec/models/fe/question_spec.rb
@@ -43,4 +43,28 @@ describe Fe::Question do
     end
   end
 
+  context 'saving' do
+    let(:e) { create(:text_field_element) }
+    let(:app) { create(:text_field_element) }
+    let(:app2) { create(:text_field_element) }
+
+    before do
+      e.set_response('answer value', app)
+    end
+
+    context '#save_file' do
+      it ' checks that the answer sheet that calls set_response is the same one that calls save' do
+        expect {
+          e.save_file(app2, nil)
+        }.to raise_error(RuntimeError, "Trying to save answers to a different answer sheet than the one given in set_response")
+      end
+    end
+    context '#save_response' do
+      it ' checks that the answer sheet that calls set_response is the same one that calls save' do
+        expect {
+          e.save_response(app2)
+        }.to raise_error(RuntimeError, "Trying to save answers to a different answer sheet than the one given in set_response")
+      end
+    end
+  end
 end


### PR DESCRIPTION
@twinge @jbirdjavi because the initial answers on the element were set using
responses(answer_sheet), that filters out empty strings.  So any update
where people hadn't chosen a dropdown value it was writing an empty
string.  You might want to check your database and see if there are a
lot of extra empty strings if you depend on pulling out answers
manually, like we are for apptrack in one-app/cap.  Using
display_response works because it already filters out empty strings

We could add where value != "" everywhere in our apptrack code but this seems like the better way to do it.  Also cleaned up the code in a few other places.