### PR TITLE
don't reset the refs when access key param a is present

### DIFF
--- a/app/controllers/fe/concerns/answer_pages_controller_concern.rb
+++ b/app/controllers/fe/concerns/answer_pages_controller_concern.rb
@@ -3,7 +3,8 @@ module Fe::AnswerPagesControllerConcern
 
   begin
     included do
-      before_filter :get_answer_sheet, :only => [:show, :edit, :update, :save_file, :index]
+      before_action :get_answer_sheet, :only => [:show, :edit, :update, :save_file, :index]
+      before_action :set_quiet_reference_email_change, only: :update
     end
   rescue ActiveSupport::Concern::MultipleIncludedBlocks
   end
@@ -101,5 +102,9 @@ module Fe::AnswerPagesControllerConcern
 
   def set_saved_at_timestamp
     @saved_at_timestamp = [@answer_sheet.updated_at, @answer_sheet.answers.maximum(:updated_at)].compact.max
+  end
+
+  def set_quiet_reference_email_change
+    @answer_sheet.allow_quiet_reference_email_changes = true if @answer_sheet.is_a?(Fe::ReferenceSheet) && params[:a].present?
   end
 end

--- a/spec/controllers/fe/answer_pages_controller_spec.rb
+++ b/spec/controllers/fe/answer_pages_controller_spec.rb
@@ -40,13 +40,17 @@ describe Fe::AnswerPagesController, type: :controller do
   end
 
   context '#update' do
-    it 'should work' do
-      answer_sheet = create(:answer_sheet)
-      page = create(:page)
-      question_sheet = page.question_sheet
+    let(:answer_sheet) { create(:answer_sheet) }
+    let(:page) { create(:page) }
+    let(:question_sheet) { question_sheet = page.question_sheet }
+    let(:element) { create(:text_field_element) }
+
+    before do
       create(:answer_sheet_question_sheet, answer_sheet: answer_sheet, question_sheet: question_sheet)
-      element = create(:text_field_element)
       create(:page_element, element: element, page: page)
+    end
+
+    it 'should work' do
       # ref
       reference_question = create(:reference_question)
       reference_sheet = create(:reference_sheet, applicant_answer_sheet_id: answer_sheet.id, email: 'initial@ref.com')
@@ -71,12 +75,6 @@ describe Fe::AnswerPagesController, type: :controller do
     end
     it 'should store a reference sheet answer' do
       # create a normal applicant sheet to make sure the answer isn't saved to that
-      answer_sheet = create(:answer_sheet)
-      page = create(:page)
-      question_sheet = page.question_sheet
-      create(:answer_sheet_question_sheet, answer_sheet: answer_sheet, question_sheet: question_sheet)
-      element = create(:text_field_element)
-      create(:page_element, element: element, page: page)
       # ref
       ref_page = create(:page, label: 'Ref Page')
       ref_question_sheet = ref_page.question_sheet
@@ -99,6 +97,33 @@ describe Fe::AnswerPagesController, type: :controller do
       expect(reference_sheet.reload.answers.collect(&:value)).to eq(['ref answer here'])
       expect(answer_sheet.reload.answers).to eq([])
     end
-  end
+    context 'when filling out a reference' do
+      it 'should not reset the reference even when the email changes' do
+        # ref
+        ref_page = create(:page, label: 'Ref Page')
+        ref_question_sheet = ref_page.question_sheet
+        ref_element = create(:text_field_element, object_name: 'answer_sheet', attribute_name: 'email')
+        create(:page_element, element: ref_element, page: ref_page)
+        reference_question = create(:reference_question, related_question_sheet_id: ref_question_sheet.id)
+        reference_sheet = create(:reference_sheet, question_id: reference_question.id, applicant_answer_sheet_id: answer_sheet.id, email: 'initial@ref.com')
+        reference_sheet.generate_access_key
+        reference_sheet.save!
+        key_before = reference_sheet.access_key
 
+        xhr :put, :update, {
+          answers: { "#{ref_element.id}" => 'other@email.com' },
+          id: ref_page.id,
+          answer_sheet_id: reference_sheet.id,
+          answer_sheet_type: 'Fe::ReferenceSheet',
+          a: reference_sheet.access_key
+        }
+
+        expect(response).to render_template('fe/answer_pages/update')
+        reference_sheet.reload
+        expect(reference_sheet.email).to eq('other@email.com')
+        # make sure the access key isn't reset
+        expect(reference_sheet.access_key).to eq(key_before)
+      end
+    end
+  end
 end

--- a/spec/models/fe/reference_question_spec.rb
+++ b/spec/models/fe/reference_question_spec.rb
@@ -27,8 +27,8 @@ describe Fe::ReferenceQuestion do
     reference_question.update_attribute(:related_question_sheet_id, qs2.id)
     expect(reference_sheet.reload.question_sheet_id).to eq(qs2.id)
 
-    # start the reference, then # change question sheet on ref element, the reference_sheet's
-    # question sheet should not change
+    # start the reference, then change question sheet on ref element, 
+    # the reference_sheet's question sheet should not change
     reference_sheet.update_attribute(:status, 'started')
     qs3 = create(:question_sheet)
     reference_question.update_attribute(:related_question_sheet_id, qs3.id)

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -148,37 +148,57 @@ describe Fe::ReferenceSheet do
   end
 
   context '#check_email_change' do
+    let(:qs) { create(:question_sheet) }
+    let(:ref_qs) { create(:question_sheet) }
+    let(:ref_tf) { create(:text_field_element) }
+    let(:q) { create(:reference_question, related_question_sheet: ref_qs) }
+    let(:applicant) { FactoryGirl.create(:fe_person) }
+    let(:application) { FactoryGirl.create(:answer_sheet, applicant_id: applicant.id) }
+    let(:r) { create(:reference_sheet, status: 'started', question: q, email_sent_at: 1.hour.ago, applicant_answer_sheet: application) }
+    let(:a) { create(:answer, value: 'test', answer_sheet_id: r.id, question: ref_tf) }
+
     before do
-      qs = create(:question_sheet)
-      ref_qs = create(:question_sheet)
       ref_qs.pages << create(:page)
-      ref_tf = create(:text_field_element)
       ref_qs.pages.first.elements << ref_tf
-      q = create(:reference_question, related_question_sheet: ref_qs)
-      @r = create(:reference_sheet, status: 'started', question: q)
-      @access_key_before = @r.access_key
-      @a = create(:answer, value: 'test', answer_sheet_id: @r.id, question: ref_tf)
+      @access_key_before = r.access_key
+      @a = create(:answer, value: 'test', answer_sheet_id: r.id, question: ref_tf)
+      create(:fe_email_template, name: 'Reference Deleted', subject: 'Reference Deleted', content: "<a href='test'>reference deleted</a>")
     end
 
     it 'should reset the answers and access key if created' do
-      @r.update_column(:status, 'created')
-      @r.update_attribute(:email, 'a@b.com')
-      expect(@r.access_key).to_not eq(@access_key_before)
-      expect(Fe::Answer.find_by(id: @a.id)).to be_nil
+      r.update_column(:status, 'created')
+      r.update_attribute(:email, 'a@b.com')
+      expect(r.access_key).to_not eq(@access_key_before)
+      expect(Fe::Answer.count).to eq(0)
     end
 
     it 'should reset the answers and access key if started' do
-      @r.update_column(:status, 'started')
-      @r.update_attribute(:email, 'a@b.com')
-      expect(@r.access_key).to_not eq(@access_key_before)
-      expect(Fe::Answer.find_by(id: @a.id)).to be_nil
+      r.update_column(:status, 'started')
+      r.update_attribute(:email, 'a@b.com')
+      expect(r.access_key).to_not eq(@access_key_before)
+      expect(Fe::Answer.count).to eq(0)
     end
 
     it 'should not reset the answers and access key if completed' do
-      @r.update_column(:status, 'completed')
-      @r.update_attribute(:email, 'a@b.com')
-      expect(@r.access_key).to eq(@access_key_before)
-      expect(Fe::Answer.find_by(id: @a.id)).to_not be_nil
+      r.update_column(:status, 'completed')
+      r.update_attribute(:email, 'a@b.com')
+      expect(r.access_key).to eq(@access_key_before)
+      expect(Fe::Answer.count).to eq(1)
+    end
+
+    it 'should not reset the answers and access key if completed' do
+      r.update_column(:status, 'completed')
+      r.update_attribute(:email, 'a@b.com')
+      expect(r.access_key).to eq(@access_key_before)
+      expect(Fe::Answer.find_by(id: a.id)).to_not be_nil
+    end
+
+    it "doesn't delete the answers if allow_quiet_reference_email_changes is set " do
+      r.update_column(:status, 'started')
+      r.update_attribute(:email, 'a@b.com')
+      r.allow_quiet_reference_email_changes = true
+      expect(r.access_key).to_not eq(@access_key_before)
+      expect(Fe::Answer.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
@twinge this fixes resetting the refs when there's an "email" element
on the reference sheet that has attribute_name pointing directly to
reference email field.  If the person filling out the reference
changed that it was resetting the refs (including all answers)