### PR TITLE
Fix grid w/ total column math

### DIFF
--- a/app/views/fe/questions/fe/_question_grid_with_total.html.erb
+++ b/app/views/fe/questions/fe/_question_grid_with_total.html.erb
@@ -27,7 +27,7 @@
   			question_grid_with_total.elements.each do |element| -%>
   			<td id="element_<%= element.id %>">
   				<%# grid_el = @elements.to_a.find {|el| el.id == element.id} %>
-          <% col_count = (col_count + 1) % question_grid_with_total.num_cols %>
+          <% col_count = col_count % question_grid_with_total.num_cols %>
   				<%= render :partial => 'fe/answer_pages/element', :object => element, :locals => {:in_grid => true, :col => col_count} %>
   			</td>
   			<%- 	col_count += 1


### PR DESCRIPTION
The col_count variable was being incremented by two in every run through the loop.  Both in line 30 and line 33.  I took out the first incrementation and let the first column be 0 since the first column can't be totaled anyway due to line 43.