### PR TITLE
Cache ref visibility

### DIFF
--- a/app/controllers/fe/concerns/answer_pages_controller_concern.rb
+++ b/app/controllers/fe/concerns/answer_pages_controller_concern.rb
@@ -33,6 +33,7 @@ module Fe::AnswerPagesControllerConcern
     questions = @presenter.all_questions_for_page(params[:id])
     questions.set_filter(get_filter)
     questions.post(answer_params, @answer_sheet)
+    questions.update_reference_sheet_visibility
 
     questions.save
 

--- a/app/controllers/fe/concerns/answer_pages_controller_concern.rb
+++ b/app/controllers/fe/concerns/answer_pages_controller_concern.rb
@@ -33,9 +33,8 @@ module Fe::AnswerPagesControllerConcern
     questions = @presenter.all_questions_for_page(params[:id])
     questions.set_filter(get_filter)
     questions.post(answer_params, @answer_sheet)
-    questions.update_reference_sheet_visibility
-
     questions.save
+    questions.update_reference_sheet_visibility
 
     @elements = questions.elements
 

--- a/app/controllers/fe/concerns/answer_pages_controller_concern.rb
+++ b/app/controllers/fe/concerns/answer_pages_controller_concern.rb
@@ -34,7 +34,7 @@ module Fe::AnswerPagesControllerConcern
     questions.set_filter(get_filter)
     questions.post(answer_params, @answer_sheet)
     questions.save
-    questions.update_reference_sheet_visibility
+    Fe::UpdateReferenceSheetVisibilityJob.perform_later(@answer_sheet, questions.questions.collect(&:id))
 
     @elements = questions.elements
 

--- a/app/jobs/fe/update_reference_sheet_visibility_job.rb
+++ b/app/jobs/fe/update_reference_sheet_visibility_job.rb
@@ -1,0 +1,12 @@
+class Fe::UpdateReferenceSheetVisibilityJob < ActiveJob::Base
+  def perform(answer_sheet, question_ids)
+    puts answer_sheet.object_id
+    answer_sheet.question_sheets_all_reference_elements.each do |r|
+      if (r.visibility_affecting_element_ids & question_ids).any?
+        answer_sheet.all_references.where(question_id: r.id).each do |ref|
+          ref.update_visible
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/fe/update_reference_sheet_visibility_job.rb
+++ b/app/jobs/fe/update_reference_sheet_visibility_job.rb
@@ -1,6 +1,5 @@
 class Fe::UpdateReferenceSheetVisibilityJob < ActiveJob::Base
   def perform(answer_sheet, question_ids)
-    puts answer_sheet.object_id
     answer_sheet.question_sheets_all_reference_elements.each do |r|
       if (r.visibility_affecting_element_ids & question_ids).any?
         answer_sheet.all_references.where(question_id: r.id).each do |ref|

--- a/app/models/fe/application.rb
+++ b/app/models/fe/application.rb
@@ -11,6 +11,8 @@ class Fe::Application < Fe::AnswerSheet
   has_many :answer_sheet_question_sheets, :foreign_key => 'answer_sheet_id'
   has_many :question_sheets, :through => :answer_sheet_question_sheets
   
+  alias_method :all_references, :references
+
   # This will be overridden by the state machine defined in the enclosing app
   def completed?
     raise "completed? should be implemented by the extending class"

--- a/app/models/fe/concerns/answer_sheet_concern.rb
+++ b/app/models/fe/concerns/answer_sheet_concern.rb
@@ -25,7 +25,6 @@ module Fe
         }, foreign_key: 'answer_sheet_id', class_name: '::Fe::Answer'
         has_many :reference_sheets, :foreign_key => 'applicant_answer_sheet_id', class_name: 'Fe::ReferenceSheet'
         has_many :payments, :foreign_key => 'application_id', class_name: 'Fe::Payment'
-        after_save :update_reference_sheet_visibility
       end
     rescue ActiveSupport::Concern::MultipleIncludedBlocks
     end
@@ -114,19 +113,11 @@ module Fe
     def question_sheets_all_reference_elements
       # forms are generally not changed often so caching on the last updated elementd
       # will provide a good balance of speed and cache invalidation
-      element_ids = Rails.cache.fetch(['answer_sheet#answer_sheet_all_reference_elements', Fe::Element.maximum(:updated_at)]) do
+      element_ids = Rails.cache.fetch(question_sheets + ['answer_sheet#answer_sheet_all_reference_elements', Fe::Element.order('updated_at desc, id desc').first]) do
         question_sheets.compact.collect { |q| q.all_elements.reference_kinds.pluck(:id) }.flatten
       end
 
       Fe::Element.find(element_ids)
-    end
-
-    def update_reference_sheet_visibility
-      question_sheets_all_reference_elements.each do |r|
-        if r.visibility_affecting_element_ids.include?(question_id)
-          r.update_visible
-        end
-      end
     end
   end
 end

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -29,6 +29,7 @@ module Fe
     scope :questions, -> { where("kind NOT IN('Fe::Paragraph', 'Fe::Section', 'Fe::QuestionGrid', 'Fe::QuestionGridWithTotal')") }
     scope :shared, -> { where(share: true) }
     scope :grid_kinds, -> { where(kind: ['Fe::QuestionGrid', 'Fe::QuestionGridWithTotal']) }
+    scope :reference_kinds, -> { where(kind: 'Fe::ReferenceSheet') }
 
     validates_presence_of :kind
     validates_presence_of :style
@@ -115,6 +116,25 @@ module Fe
         end
 
         return el
+      end
+    end
+
+    # return an array of all elements whose answers or visibility might affect
+    # the visibility of this element
+    def visibility_affecting_element_ids
+      return @visibility_affecting_element_ids if @visibility_affecting_element_ids
+
+      # the form doesn't change much so caching on the last updated element will
+      # provide a good balance of speed and cache invalidation
+      Rails.cache.fetch([self, 'element#visibility_affecting_element_ids', Fe::Element.maximum(:updated_at)]) do
+        elements = []
+
+        elements << question_grid if question_grid
+        elements << choice_field if choice_field
+        elements += Fe::Element.where(conditional_type: 'Fe::Element', conditional_id: id)
+        element_ids = elements.collect(&:id) +
+          elements.collect { |e| e.visibility_affecting_element_ids }.flatten
+        element_ids.uniq
       end
     end
 

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -29,7 +29,7 @@ module Fe
     scope :questions, -> { where("kind NOT IN('Fe::Paragraph', 'Fe::Section', 'Fe::QuestionGrid', 'Fe::QuestionGridWithTotal')") }
     scope :shared, -> { where(share: true) }
     scope :grid_kinds, -> { where(kind: ['Fe::QuestionGrid', 'Fe::QuestionGridWithTotal']) }
-    scope :reference_kinds, -> { where(kind: 'Fe::ReferenceSheet') }
+    scope :reference_kinds, -> { where(kind: 'Fe::ReferenceQuestion') }
 
     validates_presence_of :kind
     validates_presence_of :style
@@ -126,7 +126,7 @@ module Fe
 
       # the form doesn't change much so caching on the last updated element will
       # provide a good balance of speed and cache invalidation
-      Rails.cache.fetch([self, 'element#visibility_affecting_element_ids', Fe::Element.maximum(:updated_at)]) do
+      Rails.cache.fetch([self, 'element#visibility_affecting_element_ids', Fe::Element.order('updated_at desc, id desc').first]) do
         elements = []
 
         elements << question_grid if question_grid

--- a/app/models/fe/page.rb
+++ b/app/models/fe/page.rb
@@ -141,20 +141,20 @@ module Fe
 
     def all_hidden_elements(answer_sheet)
       @all_hidden_elements ||= {}
-      @all_hidden_elements[answer_sheet] ||= build_all_hidden_elements(answer_sheet)
+      @all_hidden_elements[answer_sheet.cache_key] ||= build_all_hidden_elements(answer_sheet)
     end
 
     def build_all_hidden_elements(answer_sheet)
       @all_hidden_elements ||= {}
-      @all_hidden_elements[answer_sheet] = []
+      @all_hidden_elements[answer_sheet.cache_key] = []
       all_elements.each do |e|
-        next if @all_hidden_elements[answer_sheet].include?(e)
+        next if @all_hidden_elements[answer_sheet.cache_key].include?(e)
         if e.hidden_by_choice_field?(answer_sheet) || e.hidden_by_conditional?(answer_sheet, self)
-          @all_hidden_elements[answer_sheet] += ([e] + e.all_elements)
-          @all_hidden_elements[answer_sheet].uniq!
+          @all_hidden_elements[answer_sheet.cache_key] += ([e] + e.all_elements)
+          @all_hidden_elements[answer_sheet.cache_key].uniq!
         end
       end
-      @all_hidden_elements[answer_sheet]
+      @all_hidden_elements[answer_sheet.cache_key]
     end
 
     def clear_all_hidden_elements

--- a/app/models/fe/question_set.rb
+++ b/app/models/fe/question_set.rb
@@ -3,7 +3,7 @@
 module Fe
   class QuestionSet
 
-    attr_reader :elements
+    attr_reader :elements, :questions
 
     # associate answers from database with a set of elements
     def initialize(elements, answer_sheet)
@@ -89,17 +89,6 @@ module Fe
       end
 
       initialize(@elements, @answer_sheet)
-    end
-
-    def update_reference_sheet_visibility
-      question_ids = @questions.collect(&:id)
-      @answer_sheet.question_sheets_all_reference_elements.each do |r|
-        if (r.visibility_affecting_element_ids & question_ids).any?
-          @answer_sheet.all_references.where(question_id: r.id).each do |ref|
-            ref.update_visible
-          end
-        end
-      end
     end
 
     private

--- a/app/models/fe/question_set.rb
+++ b/app/models/fe/question_set.rb
@@ -91,6 +91,15 @@ module Fe
       initialize(@elements, @answer_sheet)
     end
 
+    def update_reference_sheet_visibility
+      question_ids = @questions.collect(&:id)
+      @answer_sheet.question_sheets_all_reference_elements.each do |r|
+        if (r.visibility_affecting_element_ids & question_ids).any?
+          r.update_visible
+        end
+      end
+    end
+
     private
 
     # convert posted response to a question into Array of values
@@ -114,6 +123,5 @@ module Fe
       # Hash may contain empty string to force post for no checkboxes
   #    values = values.reject {|r| r == ''}
     end
-
   end
 end

--- a/app/models/fe/question_set.rb
+++ b/app/models/fe/question_set.rb
@@ -95,7 +95,9 @@ module Fe
       question_ids = @questions.collect(&:id)
       @answer_sheet.question_sheets_all_reference_elements.each do |r|
         if (r.visibility_affecting_element_ids & question_ids).any?
-          r.update_visible
+          @answer_sheet.all_references.where(question_id: r.id).each do |ref|
+            ref.update_visible
+          end
         end
       end
     end

--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -87,9 +87,6 @@ module Fe
     alias_method :application, :applicant_answer_sheet
     delegate :applicant, to: :application
 
-    def visibility_affecting_questions
-    end
-
     def computed_visibility_cache_key
       return @computed_visibility_cache_key if @computed_visibility_cache_key
       answers = Fe::Answer.where(question_id: question.visibility_affecting_element_ids, 

--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -34,6 +34,7 @@ module Fe
     after_save :notify_old_reference_not_needed, if: :new_reference_requested?
     before_create :set_question_sheet
     after_destroy :notify_reference_of_deletion
+    after_create :update_visible
 
     aasm :column => :status do
 
@@ -89,6 +90,7 @@ module Fe
 
     def computed_visibility_cache_key
       return @computed_visibility_cache_key if @computed_visibility_cache_key
+      return nil unless question # keep from crashing for tests
       answers = Fe::Answer.where(question_id: question.visibility_affecting_element_ids, 
                                  answer_sheet_id: applicant_answer_sheet)
       answers.collect(&:cache_key).join('/')

--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -98,10 +98,11 @@ module Fe
       if visibility_cache_key == computed_visibility_cache_key
         visible
       else
-        is_visible = question.visible?(applicant_answer_sheet, page)
+        self.visible = question.visible?(applicant_answer_sheet, page)
+        self.visibility_cache_key = computed_visibility_cache_key
         # save only these columns and don't check validations, but do record updated_at
         # as it is significant enough of an event that we probably want that to set updated_at
-        Fe::ReferenceSheet.where(id: id).update_all(visibility_cache_key: computed_visibility_cache_key, visible: is_visible, updated_at: Time.now)
+        Fe::ReferenceSheet.where(id: id).update_all(visibility_cache_key: self.computed_visibility_cache_key, visible: self.visible, updated_at: Time.now)
       end
     end
 

--- a/db/migrate/20160201185838_add_visible_and_visibility_cache_key_to_reference_sheets.rb
+++ b/db/migrate/20160201185838_add_visible_and_visibility_cache_key_to_reference_sheets.rb
@@ -1,0 +1,6 @@
+class AddVisibleAndVisibilityCacheKeyToReferenceSheets < ActiveRecord::Migration
+  def change
+    add_column Fe::ReferenceSheet.table_name, :visible, :boolean
+    add_column Fe::ReferenceSheet.table_name, :visibility_cache_key, :string
+  end
+end

--- a/fe.gemspec
+++ b/fe.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency 'rails', '>= 3.1.0'
+  s.add_dependency 'rails', '~> 4.2'
   s.add_dependency 'acts_as_list', '= 0.7.2'
   s.add_dependency 'aasm', '~> 3.4.0'
   s.add_dependency 'jquery-rails'

--- a/spec/dummy/db/migrate/20160204164613_add_visible_and_visibility_cache_key_to_reference_sheets.fe_engine.rb
+++ b/spec/dummy/db/migrate/20160204164613_add_visible_and_visibility_cache_key_to_reference_sheets.fe_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from fe_engine (originally 20160201185838)
+class AddVisibleAndVisibilityCacheKeyToReferenceSheets < ActiveRecord::Migration
+  def change
+    add_column Fe::ReferenceSheet.table_name, :visible, :boolean
+    add_column Fe::ReferenceSheet.table_name, :visibility_cache_key, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,41 +11,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151021190027) do
+ActiveRecord::Schema.define(version: 20160204164613) do
 
-  create_table "fe_addresses", force: true do |t|
+  create_table "fe_addresses", force: :cascade do |t|
     t.datetime "startdate"
     t.datetime "enddate"
-    t.string   "address1"
-    t.string   "address2"
-    t.string   "address3"
-    t.string   "address4"
-    t.string   "address_type"
-    t.string   "city"
-    t.string   "state"
-    t.string   "zip"
-    t.string   "country"
-    t.integer  "person_id"
+    t.string   "address1",     limit: 255
+    t.string   "address2",     limit: 255
+    t.string   "address3",     limit: 255
+    t.string   "address4",     limit: 255
+    t.string   "address_type", limit: 255
+    t.string   "city",         limit: 255
+    t.string   "state",        limit: 255
+    t.string   "zip",          limit: 255
+    t.string   "country",      limit: 255
+    t.integer  "person_id",    limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "fe_answer_sheet_question_sheets", force: true do |t|
-    t.integer  "answer_sheet_id"
-    t.integer  "question_sheet_id"
+  create_table "fe_answer_sheet_question_sheets", force: :cascade do |t|
+    t.integer  "answer_sheet_id",   limit: 4
+    t.integer  "question_sheet_id", limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "fe_answer_sheet_question_sheets", ["answer_sheet_id", "question_sheet_id"], name: "answer_sheet_question_sheet", using: :btree
 
-  create_table "fe_answers", force: true do |t|
-    t.integer  "answer_sheet_id",         null: false
-    t.integer  "question_id",             null: false
-    t.text     "value"
-    t.integer  "attachment_file_size"
-    t.string   "attachment_content_type"
-    t.string   "attachment_file_name"
+  create_table "fe_answers", force: :cascade do |t|
+    t.integer  "answer_sheet_id",         limit: 4,     null: false
+    t.integer  "question_id",             limit: 4,     null: false
+    t.text     "value",                   limit: 65535
+    t.integer  "attachment_file_size",    limit: 4
+    t.string   "attachment_content_type", limit: 255
+    t.string   "attachment_file_name",    limit: 255
     t.datetime "attachment_updated_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -53,23 +53,23 @@ ActiveRecord::Schema.define(version: 20151021190027) do
 
   add_index "fe_answers", ["answer_sheet_id", "question_id"], name: "answer_sheet_question", using: :btree
 
-  create_table "fe_applications", force: true do |t|
-    t.integer  "applicant_id"
-    t.string   "status"
+  create_table "fe_applications", force: :cascade do |t|
+    t.integer  "applicant_id", limit: 4
+    t.string   "status",       limit: 255
     t.datetime "submitted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "locale",       default: "en"
+    t.string   "locale",       limit: 255, default: "en"
   end
 
   add_index "fe_applications", ["applicant_id"], name: "question_sheet_id", using: :btree
 
-  create_table "fe_conditions", force: true do |t|
-    t.integer  "question_sheet_id", null: false
-    t.integer  "trigger_id",        null: false
-    t.string   "expression",        null: false
-    t.integer  "toggle_page_id",    null: false
-    t.integer  "toggle_id"
+  create_table "fe_conditions", force: :cascade do |t|
+    t.integer  "question_sheet_id", limit: 4,   null: false
+    t.integer  "trigger_id",        limit: 4,   null: false
+    t.string   "expression",        limit: 255, null: false
+    t.integer  "toggle_page_id",    limit: 4,   null: false
+    t.integer  "toggle_id",         limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -79,143 +79,145 @@ ActiveRecord::Schema.define(version: 20151021190027) do
   add_index "fe_conditions", ["toggle_page_id"], name: "index_fe_conditions_on_toggle_page_id", using: :btree
   add_index "fe_conditions", ["trigger_id"], name: "index_fe_conditions_on_trigger_id", using: :btree
 
-  create_table "fe_elements", force: true do |t|
-    t.integer  "question_grid_id"
-    t.string   "kind",                      limit: 40,                 null: false
+  create_table "fe_elements", force: :cascade do |t|
+    t.integer  "question_grid_id",          limit: 4
+    t.string   "kind",                      limit: 40,                    null: false
     t.string   "style",                     limit: 40
-    t.string   "label"
-    t.text     "content"
+    t.string   "label",                     limit: 255
+    t.text     "content",                   limit: 65535
     t.boolean  "required"
     t.string   "slug",                      limit: 36
-    t.integer  "position"
-    t.string   "object_name"
-    t.string   "attribute_name"
-    t.string   "source"
-    t.string   "value_xpath"
-    t.string   "text_xpath"
-    t.string   "cols"
-    t.boolean  "is_confidential",                      default: false
-    t.string   "total_cols"
-    t.string   "css_id"
-    t.string   "css_class"
+    t.integer  "position",                  limit: 4
+    t.string   "object_name",               limit: 255
+    t.string   "attribute_name",            limit: 255
+    t.string   "source",                    limit: 255
+    t.string   "value_xpath",               limit: 255
+    t.string   "text_xpath",                limit: 255
+    t.string   "cols",                      limit: 255
+    t.boolean  "is_confidential",                         default: false
+    t.string   "total_cols",                limit: 255
+    t.string   "css_id",                    limit: 255
+    t.string   "css_class",                 limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "related_question_sheet_id"
-    t.integer  "conditional_id"
-    t.text     "tooltip"
-    t.boolean  "hide_label",                           default: false
-    t.boolean  "hide_option_labels",                   default: false
-    t.integer  "max_length"
-    t.string   "conditional_type"
-    t.text     "conditional_answer"
-    t.integer  "choice_field_id"
-    t.boolean  "share",                                default: false
-    t.text     "label_translations"
-    t.text     "tip_translations"
-    t.text     "content_translations"
+    t.integer  "related_question_sheet_id", limit: 4
+    t.integer  "conditional_id",            limit: 4
+    t.text     "tooltip",                   limit: 65535
+    t.boolean  "hide_label",                              default: false
+    t.boolean  "hide_option_labels",                      default: false
+    t.integer  "max_length",                limit: 4
+    t.string   "conditional_type",          limit: 255
+    t.text     "conditional_answer",        limit: 65535
+    t.integer  "choice_field_id",           limit: 4
+    t.boolean  "share",                                   default: false
+    t.text     "label_translations",        limit: 65535
+    t.text     "tip_translations",          limit: 65535
+    t.text     "content_translations",      limit: 65535
   end
 
   add_index "fe_elements", ["conditional_id"], name: "index_fe_elements_on_conditional_id", using: :btree
   add_index "fe_elements", ["question_grid_id"], name: "index_fe_elements_on_question_grid_id", using: :btree
   add_index "fe_elements", ["slug"], name: "index_fe_elements_on_slug", using: :btree
 
-  create_table "fe_email_templates", force: true do |t|
-    t.string   "name",       limit: 1000, null: false
-    t.text     "content"
+  create_table "fe_email_templates", force: :cascade do |t|
+    t.string   "name",       limit: 1000,  null: false
+    t.text     "content",    limit: 65535
     t.boolean  "enabled"
-    t.string   "subject"
+    t.string   "subject",    limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "fe_page_elements", force: true do |t|
-    t.integer  "page_id"
-    t.integer  "element_id"
-    t.integer  "position"
+  create_table "fe_page_elements", force: :cascade do |t|
+    t.integer  "page_id",    limit: 4
+    t.integer  "element_id", limit: 4
+    t.integer  "position",   limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "fe_page_elements", ["page_id", "element_id"], name: "page_element", using: :btree
 
-  create_table "fe_pages", force: true do |t|
-    t.integer  "question_sheet_id",                             null: false
-    t.string   "label",              limit: 60,                 null: false
-    t.integer  "number"
-    t.boolean  "no_cache",                      default: false
-    t.boolean  "hidden",                        default: false
+  create_table "fe_pages", force: :cascade do |t|
+    t.integer  "question_sheet_id",  limit: 4,                     null: false
+    t.string   "label",              limit: 60,                    null: false
+    t.integer  "number",             limit: 4
+    t.boolean  "no_cache",                         default: false
+    t.boolean  "hidden",                           default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "all_element_ids"
-    t.text     "label_translations"
+    t.text     "all_element_ids",    limit: 65535
+    t.text     "label_translations", limit: 65535
   end
 
-  create_table "fe_people", force: true do |t|
+  create_table "fe_people", force: :cascade do |t|
     t.string   "first_name", limit: 50
     t.string   "last_name",  limit: 50
-    t.integer  "user_id"
+    t.integer  "user_id",    limit: 4
     t.boolean  "is_staff"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "fe_question_sheets", force: true do |t|
-    t.string   "label",      limit: 100,                 null: false
-    t.boolean  "archived",               default: false
+  create_table "fe_question_sheets", force: :cascade do |t|
+    t.string   "label",      limit: 100,                   null: false
+    t.boolean  "archived",                 default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "languages"
+    t.text     "languages",  limit: 65535
   end
 
-  create_table "fe_references", force: true do |t|
-    t.integer  "question_id"
-    t.integer  "applicant_answer_sheet_id"
+  create_table "fe_references", force: :cascade do |t|
+    t.integer  "question_id",               limit: 4
+    t.integer  "applicant_answer_sheet_id", limit: 4
     t.datetime "email_sent_at"
-    t.string   "relationship"
-    t.string   "title"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "phone"
-    t.string   "email"
-    t.string   "status"
+    t.string   "relationship",              limit: 255
+    t.string   "title",                     limit: 255
+    t.string   "first_name",                limit: 255
+    t.string   "last_name",                 limit: 255
+    t.string   "phone",                     limit: 255
+    t.string   "email",                     limit: 255
+    t.string   "status",                    limit: 255
     t.datetime "submitted_at"
     t.datetime "started_at"
-    t.string   "access_key"
+    t.string   "access_key",                limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "locale",                    default: "en"
-    t.integer  "question_sheet_id"
+    t.string   "locale",                    limit: 255, default: "en"
+    t.integer  "question_sheet_id",         limit: 4
+    t.boolean  "visible"
+    t.string   "visibility_cache_key",      limit: 255
   end
 
   add_index "fe_references", ["applicant_answer_sheet_id"], name: "index_fe_references_on_applicant_answer_sheet_id", using: :btree
   add_index "fe_references", ["question_id"], name: "index_fe_references_on_question_id", using: :btree
 
-  create_table "fe_users", force: true do |t|
-    t.integer  "user_id"
+  create_table "fe_users", force: :cascade do |t|
+    t.integer  "user_id",    limit: 4
     t.datetime "last_login"
-    t.string   "type"
-    t.string   "role"
+    t.string   "type",       limit: 255
+    t.string   "role",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "phone_numbers", force: true do |t|
-    t.string   "number"
-    t.string   "extensions"
-    t.integer  "person_id"
-    t.string   "location"
+  create_table "phone_numbers", force: :cascade do |t|
+    t.string   "number",           limit: 255
+    t.string   "extensions",       limit: 255
+    t.integer  "person_id",        limit: 4
+    t.string   "location",         limit: 255
     t.boolean  "primary"
-    t.string   "txt_to_email"
-    t.integer  "carrier_id"
+    t.string   "txt_to_email",     limit: 255
+    t.integer  "carrier_id",       limit: 4
     t.datetime "email_updated_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "users", force: true do |t|
-    t.string  "username"
-    t.string  "email"
-    t.integer "person_id"
+  create_table "users", force: :cascade do |t|
+    t.string  "username",  limit: 255
+    t.string  "email",     limit: 255
+    t.integer "person_id", limit: 4
   end
 
 end

--- a/spec/jobs/fe/update_reference_sheet_visibility_job_spec.rb
+++ b/spec/jobs/fe/update_reference_sheet_visibility_job_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Fe::UpdateReferenceSheetVisibilityJob, type: :job do
+  it "matches with enqueued job" do
+    expect {
+      Fe::UpdateReferenceSheetVisibilityJob.perform_later(create(:application), [1])
+    }.to have_enqueued_job(Fe::UpdateReferenceSheetVisibilityJob)
+  end
+
+  context '#perform' do
+    let(:qs) { create(:question_sheet_with_pages) }
+    let(:qs2) { create(:question_sheet_with_pages) }
+    let(:p) { qs.pages.first }
+    let(:p2) { qs.pages.first }
+    let(:ref_el) { create(:reference_element) }
+    let(:ref_el2) { create(:reference_element) }
+    let(:ref_el3) { create(:reference_element) }
+    let(:app) { create(:application) }
+    let(:affecting_el) { create(:text_field_element) }
+
+    before do
+      p.elements << ref_el
+      p2.elements << ref_el2
+      app.question_sheets << qs << qs2
+    end
+
+    it "calls update_visible for all refs whose visibility_affecting_element_ids include the answer's question" do
+      expect(app).to receive(:question_sheets_all_reference_elements).and_return([ref_el, ref_el2])
+      expect(ref_el).to receive(:visibility_affecting_element_ids).and_return([affecting_el.id])
+      expect(ref_el).to receive(:update_visible)
+      ref_el_arr = [ref_el]
+      allow(app).to receive(:all_references).and_return(ref_el_arr)
+      allow(ref_el_arr).to receive(:where).with(question_id: ref_el.id).and_return(ref_el_arr)
+      expect(ref_el2).to receive(:visibility_affecting_element_ids).and_return([])
+      qs = Fe::QuestionSet.new([affecting_el], app)
+      puts app.object_id
+      Fe::UpdateReferenceSheetVisibilityJob.new.perform(app, qs.questions.collect(&:id))
+    end
+  end
+end

--- a/spec/models/fe/application_spec.rb
+++ b/spec/models/fe/application_spec.rb
@@ -6,6 +6,21 @@ RSpec.describe Fe::Application, :type => :model do
   it { expect have_many :answers }
   it { expect have_many :reference_sheets }
 
+  let(:qs) { create(:question_sheet_with_pages) }
+  let(:qs2) { create(:question_sheet_with_pages) }
+  let(:p) { qs.pages.first }
+  let(:p2) { qs.pages.first }
+  let(:ref_el) { create(:reference_element) }
+  let(:ref_el2) { create(:reference_element) }
+  let(:ref_el3) { create(:reference_element) }
+  let(:app) { create(:application) }
+
+  before do
+    p.elements << ref_el
+    p2.elements << ref_el2
+    app.question_sheets << qs << qs2
+  end
+
   context '#percentage_complete' do
     before do
       @q = create(:question_sheet_with_pages)
@@ -69,14 +84,13 @@ RSpec.describe Fe::Application, :type => :model do
 
   context '#question_sheets_all_reference_elements' do
     it 'returns all reference elements for all question sheets' do
+      expect(app.question_sheets_all_reference_elements).to eq([ref_el, ref_el2])
     end
 
     it 'returns a reference that was just added' do
-    end
-  end
-
-  context '#update_reference_sheet_visibility' do
-    it "calls update_visible for all refs whose visibility_affecting_element_ids include the answer's question" do
+      expect(app.question_sheets_all_reference_elements).to eq([ref_el, ref_el2])
+      p.elements << ref_el3
+      expect(app.question_sheets_all_reference_elements).to eq([ref_el, ref_el2, ref_el3])
     end
   end
 end

--- a/spec/models/fe/application_spec.rb
+++ b/spec/models/fe/application_spec.rb
@@ -58,9 +58,11 @@ RSpec.describe Fe::Application, :type => :model do
     end
 
     it 'counts only required elements by default' do
+      @a.reload
       expect(@a.percent_complete).to eq(50) # 2 of 4
     end
     it 'counts all questions, not just required ones, when specified' do
+      @a.reload
       expect(@a.percent_complete(false)).to eq(75) # 6 of 8 (2 yes/no + 3 txts within the 1 visible grid + 3 txts directly on page)
     end
   end

--- a/spec/models/fe/application_spec.rb
+++ b/spec/models/fe/application_spec.rb
@@ -66,4 +66,17 @@ RSpec.describe Fe::Application, :type => :model do
       expect(@a.percent_complete(false)).to eq(75) # 6 of 8 (2 yes/no + 3 txts within the 1 visible grid + 3 txts directly on page)
     end
   end
+
+  context '#question_sheets_all_reference_elements' do
+    it 'returns all reference elements for all question sheets' do
+    end
+
+    it 'returns a reference that was just added' do
+    end
+  end
+
+  context '#update_reference_sheet_visibility' do
+    it "calls update_visible for all refs whose visibility_affecting_element_ids include the answer's question" do
+    end
+  end
 end

--- a/spec/models/fe/element_spec.rb
+++ b/spec/models/fe/element_spec.rb
@@ -464,13 +464,44 @@ describe Fe::Element do
   end
 
   context '#visibility_affecting_element_ids' do
+    let(:grid_el) { create(:question_grid) }
+    let(:grid_cond) { create(:choice_field_element, label: "Is the grid visible?", conditional_type: "Fe::Element", conditional_id: grid_el.id, conditional_answer: "yes") }
+    let(:ref_el) { create(:reference_element, question_grid_id: grid_el.id) }
+    let(:choice) { create(:choice_field_element, label: "is the ref element inside this element visible?") }
+    let(:ref_el2) { create(:reference_element, choice_field_id: choice.id) }
+    let(:choice_cond) { create(:choice_field_element, label: "Is the next choice element visible?", conditional_type: "Fe::Element", conditional_id: choice.id, conditional_answer: "yes") }
+    let(:ref_el3_cond) { create(:choice_field_element, label: "Is the next ref element visible?", conditional_type: "Fe::Element", conditional_id: ref_el3.id, conditional_answer: "yes") }
+    let(:ref_el3) { create(:reference_element) }
+
+    before do
+      # make sure all the elements are created
+      grid_el
+      grid_cond
+      ref_el
+      choice
+      ref_el2
+      choice_cond
+      ref_el3_cond
+      ref_el3
+    end
+
     it 'recomputes the visibility affecting element ids after a new element is added' do
+      expect(ref_el.visibility_affecting_element_ids).to eq([grid_el.id, grid_cond.id])
+      # add a new visibility affecting element and it should pick it up
+      # need to instantiate the ref_el again though to clear out the in-memory
+      # instance variable cache
+      ref_el1 = Fe::Element.find(ref_el.id)
+      grid_cond_cond = create(:choice_field_element, label: "Is the grid conditional visible?", conditional_type: "Fe::Element", conditional_id: grid_cond.id, conditional_answer: "yes")
+      expect(ref_el1.visibility_affecting_element_ids).to eq([grid_el.id, grid_cond.id, grid_cond_cond.id])
     end
     it 'includes affecting element ids of an element in a grid' do
+      expect(ref_el.visibility_affecting_element_ids).to eq([grid_el.id, grid_cond.id])
     end
     it 'includes affecting element ids of an element in a choice field' do
+      expect(ref_el2.visibility_affecting_element_ids).to eq([choice.id, choice_cond.id])
     end
     it 'includes directly affecting element ids' do
+      expect(ref_el3.visibility_affecting_element_ids).to eq([ref_el3_cond.id])
     end
   end
 end

--- a/spec/models/fe/element_spec.rb
+++ b/spec/models/fe/element_spec.rb
@@ -459,4 +459,15 @@ describe Fe::Element do
       end
     end
   end
+
+  context '#visibility_affecting_element_ids' do
+    it 'recomputes the visibility affecting element ids after a new element is added' do
+    end
+    it 'includes affecting element ids of an element in a grid' do
+    end
+    it 'includes affecting element ids of an element in a choice field' do
+    end
+    it 'includes directly affecting element ids' do
+    end
+  end
 end

--- a/spec/models/fe/element_spec.rb
+++ b/spec/models/fe/element_spec.rb
@@ -132,7 +132,7 @@ describe Fe::Element do
   it "should not let a hidden page make the questionnaire incomplete" do
     question_sheet = FactoryGirl.create(:question_sheet_with_pages)
     hide_page = question_sheet.pages[4]
-    conditional_el = FactoryGirl.create(:choice_field_element, label: "This is a test for a yes/no question that will hide the next page", conditional_type: "Fe::Page", conditional_id: hide_page.id, conditional_answer: "yes")
+    conditional_el = FactoryGirl.create(:choice_field_element, label: "This is a test for a yes/no question that will hide the page", conditional_type: "Fe::Page", conditional_id: hide_page.id, conditional_answer: "yes")
     question_sheet.pages.reload
     question_sheet.pages[3].elements << conditional_el
     conditional_el.reload
@@ -146,11 +146,12 @@ describe Fe::Element do
     application = FactoryGirl.create(:answer_sheet)
     application.answer_sheet_question_sheet = FactoryGirl.create(:answer_sheet_question_sheet, answer_sheet: application, question_sheet: question_sheet)
     application.answer_sheet_question_sheets.first.update_attributes(question_sheet_id: question_sheet.id)
+    application.reload
 
     # validate the hidden page, it should be marked complete
     expect(hide_page.complete?(application)).to eq(true)
 
-    # make the answer to the conditional question 'yes' so that the element shows up and is thus required
+    # make the answer to the conditional question 'yes' so that the page is now visible
     conditional_el.set_response("yes", application)
     conditional_el.save_response(application)
 
@@ -180,6 +181,7 @@ describe Fe::Element do
     application = FactoryGirl.create(:answer_sheet)
     application.answer_sheet_question_sheet = FactoryGirl.create(:answer_sheet_question_sheet, answer_sheet: application, question_sheet: question_sheet)
     application.answer_sheet_question_sheets.first.update_attributes(question_sheet_id: question_sheet.id)
+    application.reload
 
     # start with all the conditional element values yes so that the element will show
     conditional_el1.set_response("yes", application)
@@ -218,6 +220,7 @@ describe Fe::Element do
     application = FactoryGirl.create(:answer_sheet)
     application.answer_sheet_question_sheet = FactoryGirl.create(:answer_sheet_question_sheet, answer_sheet: application, question_sheet: question_sheet)
     application.answer_sheet_question_sheets.first.update_attributes(question_sheet_id: question_sheet.id)
+    application.reload
 
     # make the answer to the conditional question 'yes' (match) so that the element is visible (and thus required)
     conditional_el.set_response("yes", application)

--- a/spec/models/fe/page_spec.rb
+++ b/spec/models/fe/page_spec.rb
@@ -14,10 +14,10 @@ describe Fe::Page do
 
   it "should not require a hidden element" do
     question_sheet = FactoryGirl.create(:question_sheet_with_pages)
-    conditional_el = FactoryGirl.create(:choice_field_element, label: "This is a test for a yes/no question that will hide the next element if the answer is yes", conditional_type: "Fe::Element", conditional_answer: "yes")
+    conditional_el = FactoryGirl.create(:choice_field_element, label: "This is a test for a yes/no question that will show the next element if the answer is yes", conditional_type: "Fe::Element", conditional_answer: "yes")
     question_sheet.pages.reload
     question_sheet.pages[3].elements << conditional_el
-    element = FactoryGirl.create(:text_field_element, label: "This is a test of a short answer that is made visible by the previous elemenet")
+    element = FactoryGirl.create(:text_field_element, label: "This is a test of a short answer that is made visible by the previous element")
     question_sheet.pages[3].elements << element
     conditional_el.reload
     expect(conditional_el.conditional).to eq(element)
@@ -26,15 +26,15 @@ describe Fe::Page do
     application = FactoryGirl.create(:answer_sheet)
     application.answer_sheet_question_sheet = FactoryGirl.create(:answer_sheet_question_sheet, answer_sheet: application, question_sheet: question_sheet)
     application.answer_sheet_question_sheets.first.update_attributes(question_sheet_id: question_sheet.id)
+    application.reload
 
-    # make the answer to the conditional question 'yes' so that the next element shows up and is thus required
+    # make the answer to the conditional question 'no' so that the next element does not show up and is not required
     conditional_el.set_response("no", application)
     conditional_el.save_response(application)
 
-    # validate the page -- the next element after the conditional should not be required
+    # validate the page -- the next element after the conditional should not be required (because it's hidden)
     page = question_sheet.pages[3]
     question_sheet.pages.reload
-    page.reload
     expect(page.complete?(application)).to eq(true)
 
     # make the answer to the conditional question 'yes' so that the next element shows up and is thus required

--- a/spec/models/fe/question_set_spec.rb
+++ b/spec/models/fe/question_set_spec.rb
@@ -92,4 +92,31 @@ describe Fe::QuestionSet do
       expect(Fe::Answer.second.question_id).to eq(@el_visible.id)
     end
   end
+
+  context '#update_reference_sheet_visibility' do
+    let(:qs) { create(:question_sheet_with_pages) }
+    let(:qs2) { create(:question_sheet_with_pages) }
+    let(:p) { qs.pages.first }
+    let(:p2) { qs.pages.first }
+    let(:ref_el) { create(:reference_element) }
+    let(:ref_el2) { create(:reference_element) }
+    let(:ref_el3) { create(:reference_element) }
+    let(:app) { create(:application) }
+    let(:affecting_el) { create(:text_field_element) }
+
+    before do
+      p.elements << ref_el
+      p2.elements << ref_el2
+      app.question_sheets << qs << qs2
+    end
+
+    it "calls update_visible for all refs whose visibility_affecting_element_ids include the answer's question" do
+      expect(app).to receive(:question_sheets_all_reference_elements).and_return([ref_el, ref_el2])
+      expect(ref_el).to receive(:visibility_affecting_element_ids).and_return([affecting_el.id])
+      expect(ref_el).to receive(:update_visible)
+      expect(ref_el2).to receive(:visibility_affecting_element_ids).and_return([])
+      qs = Fe::QuestionSet.new([affecting_el], app)
+      qs.update_reference_sheet_visibility
+    end
+  end
 end

--- a/spec/models/fe/question_set_spec.rb
+++ b/spec/models/fe/question_set_spec.rb
@@ -114,6 +114,9 @@ describe Fe::QuestionSet do
       expect(app).to receive(:question_sheets_all_reference_elements).and_return([ref_el, ref_el2])
       expect(ref_el).to receive(:visibility_affecting_element_ids).and_return([affecting_el.id])
       expect(ref_el).to receive(:update_visible)
+      ref_el_arr = [ref_el]
+      allow(app).to receive(:all_references).and_return(ref_el_arr)
+      allow(ref_el_arr).to receive(:where).with(question_id: ref_el.id).and_return(ref_el_arr)
       expect(ref_el2).to receive(:visibility_affecting_element_ids).and_return([])
       qs = Fe::QuestionSet.new([affecting_el], app)
       qs.update_reference_sheet_visibility

--- a/spec/models/fe/question_set_spec.rb
+++ b/spec/models/fe/question_set_spec.rb
@@ -92,34 +92,4 @@ describe Fe::QuestionSet do
       expect(Fe::Answer.second.question_id).to eq(@el_visible.id)
     end
   end
-
-  context '#update_reference_sheet_visibility' do
-    let(:qs) { create(:question_sheet_with_pages) }
-    let(:qs2) { create(:question_sheet_with_pages) }
-    let(:p) { qs.pages.first }
-    let(:p2) { qs.pages.first }
-    let(:ref_el) { create(:reference_element) }
-    let(:ref_el2) { create(:reference_element) }
-    let(:ref_el3) { create(:reference_element) }
-    let(:app) { create(:application) }
-    let(:affecting_el) { create(:text_field_element) }
-
-    before do
-      p.elements << ref_el
-      p2.elements << ref_el2
-      app.question_sheets << qs << qs2
-    end
-
-    it "calls update_visible for all refs whose visibility_affecting_element_ids include the answer's question" do
-      expect(app).to receive(:question_sheets_all_reference_elements).and_return([ref_el, ref_el2])
-      expect(ref_el).to receive(:visibility_affecting_element_ids).and_return([affecting_el.id])
-      expect(ref_el).to receive(:update_visible)
-      ref_el_arr = [ref_el]
-      allow(app).to receive(:all_references).and_return(ref_el_arr)
-      allow(ref_el_arr).to receive(:where).with(question_id: ref_el.id).and_return(ref_el_arr)
-      expect(ref_el2).to receive(:visibility_affecting_element_ids).and_return([])
-      qs = Fe::QuestionSet.new([affecting_el], app)
-      qs.update_reference_sheet_visibility
-    end
-  end
 end

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -202,17 +202,81 @@ describe Fe::ReferenceSheet do
     end
   end
 
-  context '#computed_visibility_cache_key' do
-    it 'returns a cache key that changes when the answers on visibility_affecting_element_ids changes' do
-    end
-  end
+  context do
+    let(:qs) { create(:question_sheet_with_pages) }
+    let(:qs2) { create(:question_sheet_with_pages) }
+    let(:p) { qs.pages.first }
+    let(:p2) { qs.pages.first }
+    let(:ref_el) { create(:reference_element) }
+    let(:ref_el2) { create(:reference_element) }
+    let(:ref_el3) { create(:reference_element) }
+    let(:app) { create(:application) }
+    let(:affecting_el) { create(:choice_field_element, label: "Is the reference required?", conditional_type: "Fe::Element", conditional_id: ref_el.id, conditional_answer: "yes") }
+    let(:ref_sheet) { create(:reference_sheet, question: ref_el, applicant_answer_sheet_id: app.id) }
 
-  context '#update_visible' do
-    it "doesn't recompute the visibility if the cache key is the same" do
+    before do
+      p.elements << affecting_el << ref_el
+      p2.elements << ref_el2
+      app.question_sheets << qs << qs2
     end
-    it 'computes the visibility and sets the cache key if cache key is initially null' do
+
+    context '#computed_visibility_cache_key' do
+      it 'returns a cache key that changes when the answers on visibility_affecting_element_ids changes' do
+        # make the answer to the conditional question 'no' so that the ref is required (optional false)
+        affecting_el.set_response('no', app)
+        affecting_el.save_response(app)
+        
+        cache_key_before = ref_sheet.computed_visibility_cache_key
+        
+        # make the answer to the conditional question 'yes' so that the ref is required (optional false)
+        sleep(1) # make sure the update_at for the answer is changed
+        affecting_el.set_response('yes', app)
+        affecting_el.save_response(app)
+        cache_key_after = ref_sheet.computed_visibility_cache_key
+
+        expect(cache_key_before).to_not eq(cache_key_after)
+      end
     end
-    it 'computes the visibility and sets the cache key if the cache key changes' do
+
+    context '#update_visible' do
+      it "doesn't recompute the visibility if the cache key is the same" do
+        # make the answer to the conditional question 'no' so that the ref is required (optional false)
+        affecting_el.set_response('no', app)
+        affecting_el.save_response(app)
+        ref_sheet.update_visible
+
+        # call update_visible again, it shouldn't update anything because the cache
+        # key hasn't changed
+        allow(ref_sheet).to receive(:question).and_return(ref_el)
+        expect(ref_el).to_not receive(:visible?)
+        ref_sheet.update_visible
+       end
+      it 'computes the visibility and sets the cache key if cache key is initially null' do
+        ref_sheet.update(visibility_cache_key: nil)
+
+        # make the answer to the conditional question 'no' so that the ref is required (optional false)
+        affecting_el.set_response('no', app)
+        affecting_el.save_response(app)
+        allow(ref_sheet).to receive(:question).and_return(ref_el)
+        expect(ref_el).to receive(:visible?).and_return(true)
+        ref_sheet.update_visible
+        ref_sheet.reload
+        expect(ref_sheet.visible).to be true
+        expect(ref_sheet.visibility_cache_key).to_not be_nil
+      end
+      it 'computes the visibility and sets the cache key if the cache key changes' do
+        ref_sheet.update(visibility_cache_key: 'something')
+
+        # make the answer to the conditional question 'no' so that the ref is required (optional false)
+        affecting_el.set_response('no', app)
+        affecting_el.save_response(app)
+        allow(ref_sheet).to receive(:question).and_return(ref_el)
+        expect(ref_el).to receive(:visible?).and_return(false)
+        ref_sheet.update_visible
+        ref_sheet.reload
+        expect(ref_sheet.visible).to be false
+        expect(ref_sheet.visibility_cache_key).to_not eq('something')
+      end
     end
   end
 end

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -201,4 +201,18 @@ describe Fe::ReferenceSheet do
       expect(Fe::Answer.count).to eq(0)
     end
   end
+
+  context '#computed_visibility_cache_key' do
+    it 'returns a cache key that changes when the answers on visibility_affecting_element_ids changes' do
+    end
+  end
+
+  context '#update_visible' do
+    it "doesn't recompute the visibility if the cache key is the same" do
+    end
+    it 'computes the visibility and sets the cache key if cache key is initially null' do
+    end
+    it 'computes the visibility and sets the cache key if the cache key changes' do
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,7 @@ Spork.prefork do
     
     config.before(:suite) do
       DatabaseCleaner.strategy = :truncation
+      ActiveJob::Base.queue_adapter = :test
 
       # this usually would go in the app/decorators folder but there's some load order issues with the dummy app
       # and it's just way easier to do it here


### PR DESCRIPTION
@twinge @jbirdjavi this PR caches the visibility of a reference sheet in a column; apps can use that to implement conditional references (ex. one-app/cap requires less references for currently-employed applicants); it stores a cache key also, and uses that cache key to avoid recomputing the visibility more than is required

I added some logic to get all elements that might affect the visibility of another element for this, I think that might come in useful later on