### PR TITLE
require visibility affecting answers before sending refs

### DIFF
--- a/app/assets/javascripts/fe/fe.public.nojquery.js
+++ b/app/assets/javascripts/fe/fe.public.nojquery.js
@@ -416,6 +416,10 @@
     remaining = maxlength - $(this).val().length;
     $('#'+$(this).attr('id')+'_count').val(remaining);
   });
+
+  $(document).on('click', 'a[disabled]', function(event) {
+    event.preventDefault();
+  });
 })(jQuery);
 
 $(function() {

--- a/app/assets/stylesheets/fe/fe.screen.css.scss.erb
+++ b/app/assets/stylesheets/fe/fe.screen.css.scss.erb
@@ -82,6 +82,10 @@ a {
     margin: 10px 0 0 0;
 }
 
+a[disabled] {
+  pointer-events: none;
+}
+
 /* PANEL */
 
 p.instruction {

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -138,6 +138,10 @@ module Fe
       end
     end
 
+    def visibility_affecting_questions
+      Fe::Question.where(id: visibility_affecting_element_ids)
+    end
+
     def hidden_by_conditional?(answer_sheet, page)
       return false unless answer_sheet.question_sheets.include?(page.question_sheet)
       prev_el = previous_element(page.question_sheet, page)

--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -188,6 +188,10 @@ module Fe
       !optional?
     end
 
+    def all_affecting_questions_answered
+      question.visibility_affecting_questions.all? { |q| q.has_response?(applicant_answer_sheet) }
+    end
+
     protected
     
     def set_question_sheet

--- a/app/views/fe/questions/fe/_reference_question.html.erb
+++ b/app/views/fe/questions/fe/_reference_question.html.erb
@@ -43,7 +43,18 @@
           'have edited the information in order for your reference to receive another email.') %>
     </strong></em></p></li>
 
-      <li><%= link_to(_('Send Email Invitation'), @answer_sheet ? send_reference_invite_fe_answer_sheet_path(@answer_sheet, :reference_id => reference.id) : '#', :class => 'reference_send_invite button no-left-margin') %>
+      <li><%= link_to(_('Send Email Invitation'), @answer_sheet ? send_reference_invite_fe_answer_sheet_path(@answer_sheet, :reference_id => reference.id) : '#', :class => 'reference_send_invite button no-left-margin', disabled: !reference.all_affecting_questions_answered) %>
+      <% unless reference.all_affecting_questions_answered %>
+        <div>
+          <strong><i>This button is disabled because there are questions that affect whether this reference is required that need to answered first:</i></strong>
+          <ul>
+            <% reference.question.visibility_affecting_questions.each do |q| %>
+              <% next if q.has_response?(@answer_sheet) %>
+              <li>"<%= q.pages.where(question_sheet_id: @answer_sheet.question_sheet_ids).first.label %>" Page: "<%= q.label %>"</li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
     <br/><%= _('Invitation last sent:') %> <span id="ref_last_sent_<%= reference.id %>"><% if reference.email_sent_at.nil? -%><%= _('Never') %><% else %><%= reference.email_sent_at.strftime("%Y-%m-%d @ %I:%M%p") %><% end %></span></li>
       <% end %>
   </ul>

--- a/spec/models/fe/element_spec.rb
+++ b/spec/models/fe/element_spec.rb
@@ -504,4 +504,16 @@ describe Fe::Element do
       expect(ref_el3.visibility_affecting_element_ids).to eq([ref_el3_cond.id])
     end
   end
+
+  context '#visibility_affecting_questions' do
+    let!(:ref_el) { create(:reference_element) }
+    let!(:text_el) { create(:text_field_element) }
+    let!(:grid_el) { create(:question_grid) }
+
+    it 'returns all questions with id in visibility_affecting_element_ids' do
+      element_ids = [ text_el.id, grid_el.id ]
+      expect(ref_el).to receive(:visibility_affecting_element_ids).and_return(element_ids)
+      expect(ref_el.visibility_affecting_questions).to eq([text_el])
+    end
+  end
 end

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -279,4 +279,26 @@ describe Fe::ReferenceSheet do
       end
     end
   end
+
+  context '#all_affecting_questions_answered' do
+    let(:p) { create(:fe_person) }
+    let(:a) { create(:answer_sheet, applicant_id: p.id) }
+    let(:ref_el) { create(:reference_element) }
+    let(:r) { create(:reference_sheet, question_id: ref_el.id, applicant_answer_sheet: a) }
+    let(:text_el) { create(:text_field_element) }
+
+    it 'returns true when all visibility affecting questions are answered' do
+      expect(r).to receive(:question).and_return(ref_el)
+      expect(ref_el).to receive(:visibility_affecting_questions).and_return([text_el])
+      text_el.set_response('some text response', a)
+      text_el.save_response(a)
+      expect(r.all_affecting_questions_answered).to be true
+    end
+
+    it 'returns false when not all visibility affecting questions are answered' do
+      expect(r).to receive(:question).and_return(ref_el)
+      expect(ref_el).to receive(:visibility_affecting_questions).and_return([text_el])
+      expect(r.all_affecting_questions_answered).to be false
+    end
+  end
 end


### PR DESCRIPTION
@twinge @jbirdjavi on one-app we are seeing students who are evidently getting coaching to send their refs out right away... but there is a question earlier on about if they're currently/previously employed within 12 months that affects whether they need all 5 refs or just 3.  This PR requires all visibility-affecting question to be answered before the send refs button is enabled