### PR TITLE
make editing references work on form editor

### DIFF
--- a/app/models/fe/reference_sheet.rb
+++ b/app/models/fe/reference_sheet.rb
@@ -189,6 +189,7 @@ module Fe
     end
 
     def all_affecting_questions_answered
+      return false unless question
       question.visibility_affecting_questions.all? { |q| q.has_response?(applicant_answer_sheet) }
     end
 

--- a/app/views/fe/questions/fe/_reference_question.html.erb
+++ b/app/views/fe/questions/fe/_reference_question.html.erb
@@ -44,7 +44,7 @@
     </strong></em></p></li>
 
       <li><%= link_to(_('Send Email Invitation'), @answer_sheet ? send_reference_invite_fe_answer_sheet_path(@answer_sheet, :reference_id => reference.id) : '#', :class => 'reference_send_invite button no-left-margin', disabled: !reference.all_affecting_questions_answered) %>
-      <% unless reference.all_affecting_questions_answered %>
+      <% if reference.question && !reference.all_affecting_questions_answered %>
         <div>
           <strong><i>This button is disabled because there are questions that affect whether this reference is required that need to answered first:</i></strong>
           <ul>

--- a/spec/models/fe/reference_sheet_spec.rb
+++ b/spec/models/fe/reference_sheet_spec.rb
@@ -288,7 +288,7 @@ describe Fe::ReferenceSheet do
     let(:text_el) { create(:text_field_element) }
 
     it 'returns true when all visibility affecting questions are answered' do
-      expect(r).to receive(:question).and_return(ref_el)
+      expect(r).to receive(:question).and_return(ref_el).twice
       expect(ref_el).to receive(:visibility_affecting_questions).and_return([text_el])
       text_el.set_response('some text response', a)
       text_el.save_response(a)
@@ -296,7 +296,7 @@ describe Fe::ReferenceSheet do
     end
 
     it 'returns false when not all visibility affecting questions are answered' do
-      expect(r).to receive(:question).and_return(ref_el)
+      expect(r).to receive(:question).and_return(ref_el).twice
       expect(ref_el).to receive(:visibility_affecting_questions).and_return([text_el])
       expect(r.all_affecting_questions_answered).to be false
     end


### PR DESCRIPTION
when editing the references in the form builder, it's trying to determine if the button should be disabled or not but it's crashing because there is no actual reference instance there