### PR TITLE
allow hashes in the values

### DIFF
--- a/app/models/fe/question_set.rb
+++ b/app/models/fe/question_set.rb
@@ -106,7 +106,9 @@ module Fe
         end
       elsif param.kind_of?(Hash)
         # from Hash with multiple answers per question
-        values = param.values.map {|v| CGI.unescape(v)}
+        # If value is also a hash, use the value hash without escaping or anything,
+        # so that custom elements can be implemented by handling set_response.
+        values = param.values.map {|v| v.is_a?(Hash) ? v : CGI.unescape(v)}
       elsif param.kind_of?(String)
         values = [CGI.unescape(param)]
       end


### PR DESCRIPTION
don't escape cgi escape the value in this case; this change enables
custom elements to pass in more detailed values.  This was motivated
from the panorama tool to make a question for which you can add or
delete any number of them.  This change enables an easy way to pass in
an arbitrary amount of answers