### PR TITLE
pass locale in query string to xml source

### DIFF
--- a/app/models/fe/concerns/choice_field_concern.rb
+++ b/app/models/fe/concerns/choice_field_concern.rb
@@ -30,7 +30,9 @@ module Fe
           values = doc.find(value_xpath).collect { |n| n.content }
           retVal = [options, values].transpose
         rescue NameError, LibXML::XML::Error
-          doc = REXML::Document.new Net::HTTP.get_response(URI.parse(source)).body
+          url = URI.parse(source)
+          url.query = [url.query, "locale=#{locale}"].compact.join('&') if locale.present?
+          doc = REXML::Document.new Net::HTTP.get_response(url).body
           retVal = [ doc.elements.collect(text_xpath){|c|c.text}, doc.elements.collect(value_xpath){|c|c.text} ].transpose
         end
       elsif content.present?


### PR DESCRIPTION
To allow translations on the xml fields, we needed to pass along the locale to the request. I just added it to the query string for simplicity.
