### PR TITLE
use fe's next() method instead of loading by constant

### DIFF
--- a/app/views/fe/answer_pages/_answer_page.html.erb
+++ b/app/views/fe/answer_pages/_answer_page.html.erb
@@ -1,6 +1,5 @@
 <% if @presenter.active_page %>
-  <% page_dom = @presenter.active_page_link.dom_id
-     next_js = load_page_js(@presenter.next_page) -%>
+  <% page_dom = @presenter.active_page_link.dom_id %>
 
   <div id="<%= page_dom %>" class="answer-page" style="<% if show_first.nil? -%>display: none;<% end -%>">  <!-- this id is parsed by fe.public.js -->
 
@@ -20,7 +19,7 @@
             <% end %>
           </ul>
 
-          <% if next_js.empty? -%>
+          <% unless @presenter.next_page -%>
             <div id="submit_message" class="validation-advice" style="display: none;"></div>
             <div>
               <button type="button" class="button save_button"><%= _('Save Now') %></button>
@@ -32,7 +31,7 @@
             </div>
             <div>
               <button type="button" class="button no-left-margin save_button"><%= _('Save Now') %></button>
-              <button type="button" class="button cru-gold" onclick="<%= next_js %>"><%= _('Next >>') %></button>
+              <button type="button" class="button cru-gold" onclick="fe.pageHandler.next(); return false;"><%= _('Next >>') %></button>
             </div>
           <% end -%>
         <% end -%>

--- a/app/views/fe/answer_sheets/_page_link.html.erb
+++ b/app/views/fe/answer_sheets/_page_link.html.erb
@@ -1,7 +1,9 @@
-<% css_class = '' %>
-<% if session[:attempted_submit] && page_link.page.has_questions? %>
-	<% css_class = page_link.page.complete?(@answer_sheet) ? 'complete' : 'incomplete' %>
-<% end %>
-<%= li_page_active_if(@presenter.active_page && page_link.page == @presenter.active_page, :id => page_link.dom_id + '-li', :class => css_class, :style => ('display:none' if page_link.page.hidden?(@answer_sheet))) do %>
-  <%= link_to_function(page_link.label(session[:locale]), load_page_js(page_link), :id => page_link.dom_id + '-link', 'data-page-id' => page_link.dom_id, :class => 'page_link', :href => page_link.load_path) %>
-<% end -%>
+<div class="application_section">
+  <% css_class = '' %>
+  <% if session[:attempted_submit] && page_link.page.has_questions? %>
+    <% css_class = page_link.page.complete?(@answer_sheet) ? 'complete' : 'incomplete' %>
+  <% end %>
+  <%= li_page_active_if(@presenter.active_page && page_link.page == @presenter.active_page, :id => page_link.dom_id + '-li', :class => css_class, :style => ('display:none' if page_link.page.hidden?(@answer_sheet))) do %>
+    <%= link_to_function(page_link.label(session[:locale]), load_page_js(page_link), :id => page_link.dom_id + '-link', 'data-page-id' => page_link.dom_id, :class => 'page_link', :href => page_link.load_path) %>
+  <% end -%>
+</div>


### PR DESCRIPTION
this properly handles going to the next page when there are hidden pages

I'm already doing basically this logic in one-app, I just hadn't backported it into fe.

Note the page links have to have application_section class in order for next() code to find the right next page.  If enclosing apps are using their own page_links but using fe's _answer_page partial, they'll need to manually add that.. but I can't think of any apps that are in that situation.