### PR TITLE
take the hidden column on pages into account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'jquery-ui-rails'
 gem 'dynamic_form'
 gem 'aasm'
 gem 'sass'
+gem 'rake', '< 11.0'
 ###
 
 ### TravisCI db drivers

--- a/app/models/fe/concerns/answer_sheet_concern.rb
+++ b/app/models/fe/concerns/answer_sheet_concern.rb
@@ -54,7 +54,7 @@ module Fe
     end
 
     def pages
-      Page.where(:question_sheet_id => question_sheets.collect(&:id)).order('number')
+      Page.where(question_sheet_id: question_sheets.collect(&:id)).visible.order('number')
     end
 
     def completely_filled_out?

--- a/app/models/fe/page.rb
+++ b/app/models/fe/page.rb
@@ -107,6 +107,8 @@ module Fe
     end
 
     def hidden?(answer_sheet)
+      return true if hidden
+
       @hidden_cache ||= {}
       return @hidden_cache[answer_sheet] if !@hidden_cache[answer_sheet].nil?
 

--- a/spec/controllers/fe/answer_sheets_controller_spec.rb
+++ b/spec/controllers/fe/answer_sheets_controller_spec.rb
@@ -108,4 +108,12 @@ describe Fe::AnswerSheetsController, type: :controller do
       expect(ref_sheet.email).to eq('email@email.com')
     end
   end
+  context '#pages' do
+    it 'filters out hidden pages' do
+      create(:answer_sheet_question_sheet, question_sheet: question_sheet, answer_sheet: answer_sheet)
+      page = create(:page, question_sheet: question_sheet)
+      page2 = create(:page, question_sheet: question_sheet, hidden: true)
+      expect(answer_sheet.pages).to eq([page])
+    end
+  end
 end

--- a/spec/models/fe/page_spec.rb
+++ b/spec/models/fe/page_spec.rb
@@ -193,4 +193,11 @@ describe Fe::Page do
       expect(p.complete?(application)).to be(true)
     end
   end
+  context '#hidden' do
+    it 'checks the hidden column' do
+      q = create(:question_sheet)
+      p = create(:page, question_sheet: q, hidden: true)
+      expect(p.hidden).to be true
+    end
+  end
 end


### PR DESCRIPTION
When working on PR I noticed pages that I didn't see in the form were coming up as requiring to be filled out when submitting.  Turns out FE isn't checking the hidden column on pages