### PR TITLE
stop unescaping input from form engine

### DIFF
--- a/app/models/fe/question_set.rb
+++ b/app/models/fe/question_set.rb
@@ -107,12 +107,9 @@ module Fe
           values = [Date.new(year.to_i, month.to_i, 1).strftime('%Y-%m-%d')]  # for mm/yy drop downs
         end
       elsif param.kind_of?(Hash)
-        # from Hash with multiple answers per question
-        # If value is also a hash, use the value hash without escaping or anything,
-        # so that custom elements can be implemented by handling set_response.
-        values = param.values.map {|v| v.is_a?(Hash) ? v : CGI.unescape(v)}
+        values = param.values
       elsif param.kind_of?(String)
-        values = [CGI.unescape(param)]
+        values = [param]
       end
 
       # Hash may contain empty string to force post for no checkboxes


### PR DESCRIPTION
somewhere along the way, rails or a javascript or a gem changed something such that the params are coming in without us needing to unescape.