### PR TITLE
fix js error about options already defined

### DIFF
--- a/app/assets/javascripts/fe/jquery.html5_upload.js
+++ b/app/assets/javascripts/fe/jquery.html5_upload.js
@@ -10,7 +10,7 @@
             return file.size || file.fileSize;
         }
         let available_events = ['onStart', 'onStartOne', 'onProgress', 'onFinishOne', 'onFinish', 'onError'];
-        let options = $.extend({
+        options = $.extend({
             onStart: function(event, total) {
                 return true;
             },

--- a/app/models/fe/question.rb
+++ b/app/models/fe/question.rb
@@ -87,7 +87,7 @@ module Fe
     # NOTE: current_person is passed in for the benefit of enclosing apps that override locked?
     # and need to lock an element depending on who the current person is
     def locked?(params, answer_sheet, presenter, current_person)
-      return true unless params['action'] == 'edit'
+      return true if params['action'] == 'show'
       if self.object_name == 'person.current_address' && ['address1','address2','city','zip','email','state','country'].include?(self.attribute_name)
         # Billing Address
         return false

--- a/lib/fe/version.rb
+++ b/lib/fe/version.rb
@@ -1,3 +1,3 @@
 module Fe
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end


### PR DESCRIPTION
Fix some questions getting locked with a check that was too broad -- summer missions for example has an "apply" action that renders a form and if a checkbox is on the first page that will always be locked without this fix.

I think this was never noticed until now because almost all questionnaires have an intro page, then future pages will get an ajax get to the edit action and it will render correctly then.