### PR TITLE
including date field attr css_class on html element

### DIFF
--- a/app/views/fe/questions/fe/_date_field.html.erb
+++ b/app/views/fe/questions/fe/_date_field.html.erb
@@ -1,6 +1,6 @@
 <% locked = date_field.locked?(params, @answer_sheet, @presenter, current_person) %>
 <%= calendar_date_select_tag "answers[#{date_field.id}]", date_field.format_date_response(@answer_sheet),
-      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page) + date_field.css_class,
+      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page) + "#{date_field&.css_class} ",
       id: dom_id(date_field),
       disabled: locked,
       readonly: true %>

--- a/app/views/fe/questions/fe/_date_field.html.erb
+++ b/app/views/fe/questions/fe/_date_field.html.erb
@@ -1,6 +1,6 @@
 <% locked = date_field.locked?(params, @answer_sheet, @presenter, current_person) %>
 <%= calendar_date_select_tag "answers[#{date_field.id}]", date_field.format_date_response(@answer_sheet),
-      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page) + " #{date_field&.css_class} ",
+      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page) + " #{date_field&.css_class}",
       id: dom_id(date_field),
       disabled: locked,
       readonly: true %>

--- a/app/views/fe/questions/fe/_date_field.html.erb
+++ b/app/views/fe/questions/fe/_date_field.html.erb
@@ -1,6 +1,6 @@
 <% locked = date_field.locked?(params, @answer_sheet, @presenter, current_person) %>
 <%= calendar_date_select_tag "answers[#{date_field.id}]", date_field.format_date_response(@answer_sheet),
-      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page) + "#{date_field&.css_class} ",
+      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page) + " #{date_field&.css_class} ",
       id: dom_id(date_field),
       disabled: locked,
       readonly: true %>

--- a/app/views/fe/questions/fe/_date_field.html.erb
+++ b/app/views/fe/questions/fe/_date_field.html.erb
@@ -1,6 +1,6 @@
 <% locked = date_field.locked?(params, @answer_sheet, @presenter, current_person) %>
 <%= calendar_date_select_tag "answers[#{date_field.id}]", date_field.format_date_response(@answer_sheet),
-      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page),
+      class: "#{"form-control" if Fe.bootstrap} text " + date_field.validation_class(@answer_sheet, @page) + date_field.css_class,
       id: dom_id(date_field),
       disabled: locked,
       readonly: true %>

--- a/lib/fe/version.rb
+++ b/lib/fe/version.rb
@@ -1,3 +1,3 @@
 module Fe
-  VERSION = "2.1.5"
+  VERSION = "2.1.6"
 end


### PR DESCRIPTION
Adding a `css_class` to an Fe::Question record `date_field` in SMT, FE did not include the class on the rendered HTML.

This would correct that.

Broken prod:
<img width="923" alt="image" src="https://github.com/user-attachments/assets/15746aa9-a465-46e1-a1b4-92d6b92a4f8f" />

QA'd locally:
<img width="1885" alt="image" src="https://github.com/user-attachments/assets/8dc8b962-2c78-4101-b982-9612621dcb99" />
