### PR TITLE
Fix Rails version checks to check correct Rails version

### DIFF
--- a/app/models/concerns/fe/choice_field_concern.rb
+++ b/app/models/concerns/fe/choice_field_concern.rb
@@ -15,7 +15,7 @@ module Fe
       included do
         has_many :elements, class_name: "Element", foreign_key: "choice_field_id", dependent: :nullify#, order: :position
         [:rating_before_label_translations, :rating_after_label_translations, :rating_na_label_translations].each do |column|
-          if Rails::VERSION::MAJOR < 7
+          if Rails.gem_version < "7.1.0"
             serialize column, Hash
           else
             serialize column, type: Hash

--- a/app/models/fe/element.rb
+++ b/app/models/fe/element.rb
@@ -50,7 +50,7 @@ module Fe
     after_save :update_any_previous_conditional_elements
 
     [:label_translations, :tip_translations, :content_translations].each do |column|
-      if Rails::VERSION::MAJOR < 7
+      if Rails.gem_version < "7.1.0"
         serialize column, Hash
       else
         serialize column, type: Hash

--- a/app/models/fe/page.rb
+++ b/app/models/fe/page.rb
@@ -45,7 +45,7 @@ module Fe
 
     # NOTE: You may need config.active_record.yaml_column_permitted_classes = [Hash, ActiveSupport::HashWithIndifferentAccess]
     # in config/application.rb or you may get Psych::DisallowedClass trying to use label_translations
-    if Rails::VERSION::MAJOR < 7
+    if Rails.gem_version < "7.1.0"
       serialize :label_translations, Hash
     else
       serialize :label_translations, type: Hash

--- a/app/models/fe/question_sheet.rb
+++ b/app/models/fe/question_sheet.rb
@@ -21,7 +21,7 @@ module Fe
 
     validates_presence_of :label
 
-    if Rails::VERSION::MAJOR < 7
+    if Rails.gem_version < "7.1.0"
       serialize :languages, Array
     else
       serialize :languages, type: Array

--- a/lib/fe/version.rb
+++ b/lib/fe/version.rb
@@ -1,3 +1,3 @@
 module Fe
-  VERSION = "2.1.6.1"
+  VERSION = "2.1.6.2"
 end


### PR DESCRIPTION
The new syntax didn't come along until Rails 7.1.