### PR TITLE
fix multiple ref emails going out

### DIFF
--- a/app/assets/javascripts/fe/fe.public.nojquery.js.erb
+++ b/app/assets/javascripts/fe/fe.public.nojquery.js.erb
@@ -2,6 +2,9 @@
 
 // used by answer sheets
 
+// Prevent duplicate event handler bindings on Turbo navigation
+window.feEventHandlersBound = window.feEventHandlersBound || false;
+
 window.fe = {};
 fe.pageHandler = {
 
@@ -416,6 +419,10 @@ fe.pageHandler = {
 };
 
 $(document).on('ready turbo:load', function () {
+  // Prevent multiple bindings of the same handlers during Turbo navigation
+  if (window.feEventHandlersBound) return;
+  window.feEventHandlersBound = true;
+
   <% if Fe.bootstrap %>
   // http://stackoverflow.com/questions/18754020/bootstrap-3-with-jquery-validation-plugin
   $.validator.setDefaults({

--- a/lib/fe/version.rb
+++ b/lib/fe/version.rb
@@ -1,3 +1,3 @@
 module Fe
-  VERSION = "2.1.7.2"
+  VERSION = "2.1.7.3"
 end


### PR DESCRIPTION
issue was on a turbolinks navigation, the javascript event handlers were getting added each navigation. So on a "Send Reference" click, multiple handlers would trigger multiple PUTS to the server