### PR TITLE
Allow Rails 8 in gemspec

### DIFF
--- a/fe.gemspec
+++ b/fe.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency 'rails', '>= 5.0.7', '< 8'
+  s.add_dependency 'rails', '>= 5.0.7', '< 9'
   s.add_dependency 'acts_as_list', '>= 0.9.17'
   s.add_dependency 'aasm', '>= 4', '< 6'
   s.add_dependency 'jquery-rails'


### PR DESCRIPTION
## Summary
- Loosen the rails dependency cap from `< 8` to `< 9` so `fe` installs cleanly under Rails 8.x.

## Test plan
- [ ] Bundle installs in a Rails 8.1 host app
- [ ] Existing test suite still passes against Rails 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)